### PR TITLE
Support to deploy/undeploy from server.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,26 @@ The `deploy` task supports deployment of one or more applications to the Liberty
 | file | Location of a single application to be deployed. See [file attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). The application type can be war, ear, rar, eba, zip , or jar. | Yes, only when the `fileset` attribute is not specified. |
 | fileset | Location of multiple applications to be deployed. See [fileset attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). | Yes, only when the `file` attribute is not specified.|
 | timeout| Waiting time before the deployment completes successfully. The default value is 30 seconds. The unit is milliseconds. | No | 
-| ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. |No |
+| ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. | No |
+| toServerXml | A true or false value that indicates deploy to the server.xml file. By default is false.| No |
+| application | One or more applications to be deployed. See [application](#application).| Yes, if toServerXml is set. |
 
 #### Examples
-
+    <!-- Deploy with fileset -->
     <wlp:deploy ref="wlp.ant.test" >
        <fileset dir="${basedir}/resources/">
              <include name="**/*.war"/>                
        </fileset>
     </wlp:deploy>
 
+    <!-- Deploy with file attribute -->
     <wlp:deploy ref="wlp.ant.test" file="${basedir}/resources/SimpleOSGiApp.eba"  timeout="40000"/>
+
+    <!-- Deploy to server.xml file -->
+    <wlp:deploy ref="wlp.ant.test" toServerXml="true">
+        <application location="{basedir}/resources/SampleWar.war"/>
+        <application location="{basedir}/resources/SampleOSGiApp.eba" name="OSGiApp"/>
+    </wlp:deploy>
 
 ### undeploy task
 ---
@@ -146,9 +155,12 @@ The `undeploy` task supports undeployment of a single application from the Liber
 | file | Name of the application to be undeployed. The application type can be war, ear, rar, eba, zip , or jar. | No |
 | patternset | Includes and excludes patterns of applications to be undeployed. See [patternset attribute in Apache Ant](http://ant.apache.org/manual/Types/patternset.html). | No |
 | timeout | Waiting time before the undeployment completes successfully. The default value is 30 seconds. The unit is milliseconds. | No | 
-| ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. | No | 
+| ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. | No |
+| fromServerXml | A true or false value that indicates undeploy from the server.xml file. By default is false.| No |
+| application | One or more applications to be undeployed. See [application](#application).| Yes, if fromServerXml is set. |
 
 When `file` has been set the `patternset` parameter will be ignored, also when the `file` and `patternset` parameters are not set the task will undeploy all the deployed applications.
+
 #### Examples
     <!-- Only undeploys the application "SimpleOSGiApp.eba" -->
     <wlp:undeploy ref="wlp.ant.test" file="SimpleOSGiApp.eba" timeout="60000" />
@@ -164,6 +176,12 @@ When `file` has been set the `patternset` parameter will be ignored, also when t
 
     <!-- This will undeploy all the applications previously deployed on the server -->
     <wlp:undeploy ref="wlp.ant.test" timeout="60000" />
+
+    <!-- Undeploy multiple applications from the server.xml file -->
+    <wlp:undeploy ref="wlp.ant.test" fromServerXml="true">
+        <application location="{basedir}/resources/SampleWar.war"/>
+        <application location="{basedir}/resources/SampleOSGiApp.eba" name="OSGiApp"/>
+    </wlp:undeploy>
 
 ### install-feature task
 ---
@@ -187,4 +205,20 @@ The `install-feature` task installs a feature packaged as a Subsystem Archive (E
     
 	<wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true"/>
 
+## Types
 
+### application
+
+The application type is used to define a new application to deploy/undeploy from the server.xml file.
+
+| Attribute | Description | Required |
+| --------- | ------------ | ----------|
+| id | A unique identifier for the application. | No |
+| location | The path to the application resource | Yes |
+| name | A descriptive/display name for the application. | No |
+| type | The application type: war, ear, or eba. | No |
+| contextRoot | The context root of the application. | No |
+
+#### Example
+
+    <application id="1" location="{basedir}/resources/SampleWAR.war" name="SampleWAR" type="war" contextRoot="/" />

--- a/src/main/java/net/wasdev/wlp/ant/DeployTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/DeployTask.java
@@ -1,78 +1,69 @@
 /**
  * (C) Copyright IBM Corporation 2014, 2015.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package net.wasdev.wlp.ant;
 
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.wasdev.wlp.ant.server.ServerXml;
+import net.wasdev.wlp.ant.server.types.Application;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.util.FileUtils;
 
 /**
- * deploy ant tasks
+ * Deploy ant tasks
  */
 public class DeployTask extends AbstractTask {
 
+    private static final long APP_START_TIMEOUT_DEFAULT = 30 * 1000;
     private final List<FileSet> apps = new ArrayList<FileSet>();
     private String filePath;
     private String timeout;
-    private static final long APP_START_TIMEOUT_DEFAULT = 30 * 1000;
 
-    @Override
-    public void execute() {
+    /**
+     * A list of applications to deploy
+     */
+    private List<Application> applications = new ArrayList<Application>();
 
-        super.initTask();
+    /**
+     * This variable indicates if the deploy is going to be to the server xml
+     * file. By default is false to create compatibility with previous versions.
+     */
+    private boolean toServerXml = false;
 
-        // Check for no arguments
-        if ((filePath == null) && (apps.size() == 0)) {
-            throw new BuildException(messages.getString("error.fileset.set"), getLocation());
-        }
-
-        final List<File> files = scanFileSets();
-
-        long appStartTimeout = APP_START_TIMEOUT_DEFAULT;
-        if (timeout != null && !timeout.equals("")) {
-            appStartTimeout = Long.valueOf(timeout);
-        }
-
-        File dropInFolder = new File(serverConfigRoot, "dropins");
-        for (File file : files) {
-            File destFile = new File(dropInFolder, file.getName());
-            log(MessageFormat.format(messages.getString("info.deploy.app"), file.getPath()));
-            try {
-                FileUtils.getFileUtils().copyFile(file, destFile, null, true);
-            } catch (IOException e) {
-                throw new BuildException(messages.getString("error.deploy.fail"));
-            }
-            // Check start message code
-            String startMessage = START_APP_MESSAGE_CODE_REG + getFileName(file.getName());
-            if (waitForStringInLog(startMessage, appStartTimeout, getLogFile()) == null) {
-                throw new BuildException(MessageFormat.format(messages.getString("error.deploy.fail"), file.getPath()));
-            }
-        }
+    /**
+     * Add an application to be deployed to a list.
+     *
+     * @param application
+     *            The application to add.
+     */
+    public void addApplication(Application application) {
+        applications.add(application);
     }
 
     /**
      * Adds a set of files (nested fileset attribute).
-     * 
+     *
      * @param fs
      *            the file set to add
      */
@@ -80,13 +71,119 @@ public class DeployTask extends AbstractTask {
         apps.add(fs);
     }
 
-    public void setFile(File app) {
-        filePath = app.getAbsolutePath();
+    @Override
+    public void execute() {
+        super.initTask();
+
+        long appStartTimeout = APP_START_TIMEOUT_DEFAULT;
+        if (timeout != null && !timeout.equals("")) {
+            appStartTimeout = Long.valueOf(timeout);
+        }
+
+        if (toServerXml == false) {
+            if (filePath == null && apps.size() == 0) {
+                throw new BuildException(
+                        messages.getString("error.fileset.set"), getLocation());
+            }
+
+            final List<File> files = scanFileSets();
+
+            File dropInFolder = new File(serverConfigRoot, "dropins");
+            for (File file : files) {
+                File destFile = new File(dropInFolder, file.getName());
+                log(MessageFormat.format(messages.getString("info.deploy.app"),
+                        file.getPath()));
+                try {
+                    FileUtils.getFileUtils().copyFile(file, destFile, null,
+                            true);
+                } catch (IOException e) {
+                    throw new BuildException(
+                            messages.getString("error.deploy.fail"));
+                }
+                // Check start message code
+                String startMessage = START_APP_MESSAGE_CODE_REG
+                        + getFileName(file.getName());
+                if (waitForStringInLog(startMessage, appStartTimeout,
+                        getLogFile()) == null) {
+                    throw new BuildException(MessageFormat.format(
+                            messages.getString("error.deploy.fail"),
+                            file.getPath()));
+                }
+            }
+        } else {
+            if (applications.size() < 1) {
+                log(messages.getString("info.deploy.serverxml.emptylist"));
+            } else {
+
+                StringBuilder buffer = new StringBuilder();
+                int size = applications.size();
+
+                for (int i = 0; i < size; i++) {
+                    buffer.append(applications.get(i).getLocation());
+                    if (i + 1 < size) {
+                        buffer.append(", ");
+                    }
+                }
+
+                log(MessageFormat.format(
+                        messages.getString("info.deploy.serverxml"),
+                        buffer.toString()));
+
+                for (Application application : applications) {
+                    if (application == null) {
+                        log(messages.getString("info.deploy.serverxml.nullapp"),
+                                Project.MSG_DEBUG);
+                    } else if (application.getLocation() == null
+                            || application.getLocation().isEmpty()) {
+                        log(messages
+                                .getString("info.deploy.serverxml.invalidapp"),
+                                Project.MSG_DEBUG);
+                    } else {
+                        // Deploying app to the server xml
+                        ServerXml server = new ServerXml(new File(
+                                serverConfigRoot, "/server.xml"));
+                        server.addApplication(application);
+
+                        // Verifying the application in the console log
+                        String startMessage = null;
+
+                        if (application.getName() != null
+                                && !application.getName().isEmpty()) {
+                            startMessage = START_APP_MESSAGE_CODE_REG
+                                    + application.getName();
+                        } else {
+                            String applicationName = new File(
+                                    application.getLocation()).getName();
+                            applicationName = applicationName.substring(0,
+                                    applicationName.length() - 4);
+                            startMessage = START_APP_MESSAGE_CODE_REG
+                                    + applicationName;
+                        }
+
+                        if (waitForStringInLog(startMessage, appStartTimeout,
+                                getLogFile()) == null) {
+                            throw new BuildException(MessageFormat.format(
+                                    messages.getString("error.deploy.fail"),
+                                    application.getName()));
+                        }
+                    }
+
+                }
+            }
+
+        }
+    }
+
+    /**
+     * @return the timeout
+     */
+    public String getTimeout() {
+        return timeout;
     }
 
     /**
      * returns the list of files (full path name) to process.
-     * 
+     *
      * @return the list of files included via the filesets.
      */
     private List<File> scanFileSets() {
@@ -95,13 +192,19 @@ public class DeployTask extends AbstractTask {
         if (filePath != null) {
             filePath = filePath.trim();
             if (filePath.length() == 0) {
-                throw new BuildException(MessageFormat.format(messages.getString("error.parameter.invalid"), "file"), getLocation());
+                throw new BuildException(MessageFormat.format(
+                        messages.getString("error.parameter.invalid"), "file"),
+                        getLocation());
             }
             File fileToDeploy = new File(filePath);
             if (!fileToDeploy.exists()) {
-                throw new BuildException(MessageFormat.format(messages.getString("error.deploy.file.noexist"), filePath), getLocation());
+                throw new BuildException(MessageFormat.format(
+                        messages.getString("error.deploy.file.noexist"),
+                        filePath), getLocation());
             } else if (fileToDeploy.isDirectory()) {
-                throw new BuildException(messages.getString("error.deploy.file.isdirectory"), getLocation());
+                throw new BuildException(
+                        messages.getString("error.deploy.file.isdirectory"),
+                        getLocation());
             } else {
                 list.add(fileToDeploy);
             }
@@ -114,9 +217,12 @@ public class DeployTask extends AbstractTask {
 
             final String[] names = ds.getIncludedFiles();
 
-            //Throw a BuildException if the directory specified as parameter is empty.
+            // Throw a BuildException if the directory specified as parameter is
+            // empty.
             if (names.length == 0) {
-                throw new BuildException(messages.getString("error.deploy.fileset.invalid"), getLocation());
+                throw new BuildException(
+                        messages.getString("error.deploy.fileset.invalid"),
+                        getLocation());
             }
 
             for (String element : names) {
@@ -127,18 +233,27 @@ public class DeployTask extends AbstractTask {
         return list;
     }
 
-    /**
-     * @return the timeout
-     */
-    public String getTimeout() {
-        return timeout;
+    public void setFile(File app) {
+        filePath = app.getAbsolutePath();
     }
 
     /**
-     * @param timeout the timeout to set
+     * @param timeout
+     *            the timeout to set
      */
     public void setTimeout(String timeout) {
         this.timeout = timeout;
+    }
+
+    /**
+     * Add a flag to perform the deploy to the server xml.
+     *
+     * @param toServerXml
+     *            True if the applications are going to be deployed to the
+     *            server xml. Otherwise, false.
+     */
+    public void setToServerXml(boolean toServerXml) {
+        this.toServerXml = toServerXml;
     }
 
 }

--- a/src/main/java/net/wasdev/wlp/ant/UndeployTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/UndeployTask.java
@@ -1,63 +1,169 @@
 /**
  * (C) Copyright IBM Corporation 2014, 2015.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package net.wasdev.wlp.ant;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.wasdev.wlp.ant.server.ServerXml;
+import net.wasdev.wlp.ant.server.types.Application;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.PatternSet;
 import org.apache.tools.ant.util.FileUtils;
 
 /**
- * undeploy ant task
+ * Undeploy ant task
  */
 public class UndeployTask extends AbstractTask {
 
+    private static final long APP_STOP_TIMEOUT_DEFAULT = 30 * 1000;
     private String fileName;
     private PatternSet pattern;
     private String timeout;
-    private static final long APP_STOP_TIMEOUT_DEFAULT = 30 * 1000;
+
+    /**
+     * A list of applications to undeploy
+     */
+    private List<Application> applications = new ArrayList<Application>();
+
+    /**
+     * This variable indicates if the undeploy is going to be from the server
+     * xml file. By default is false to create compatibility with previous
+     * versions.
+     */
+    private boolean fromServerXml = false;
+
+    /**
+     * Add an application to be undeployed from the server xml file.
+     *
+     * @param application
+     *            The application to remove.
+     */
+    public void addApplication(Application application) {
+        applications.add(application);
+    }
+
+    public void addPatternset(PatternSet pattern) {
+        this.pattern = pattern;
+    }
 
     @Override
     public void execute() {
         super.initTask();
 
-        final List<File> files = scanFileSets();
-
         long appStopTimeout = APP_STOP_TIMEOUT_DEFAULT;
         if (timeout != null && !timeout.equals("")) {
             appStopTimeout = Long.valueOf(timeout);
         }
-        
-        for (File file : files) {
-            log(MessageFormat.format(messages.getString("info.undeploy"), file.getName()));
-            FileUtils.delete(file);
 
-            //check stop message code
-            String stopMessage = STOP_APP_MESSAGE_CODE_REG + getFileName(file.getName());
-            if (waitForStringInLog(stopMessage, appStopTimeout, getLogFile()) == null) {
-                throw new BuildException(MessageFormat.format(messages.getString("error.undeploy.fail"), file.getPath()));
+        if (fromServerXml == false) {
+            final List<File> files = scanFileSets();
+
+            for (File file : files) {
+                log(MessageFormat.format(messages.getString("info.undeploy"),
+                        file.getName()));
+                FileUtils.delete(file);
+
+                // check stop message code
+                String stopMessage = STOP_APP_MESSAGE_CODE_REG
+                        + getFileName(file.getName());
+                if (waitForStringInLog(stopMessage, appStopTimeout,
+                        getLogFile()) == null) {
+                    throw new BuildException(MessageFormat.format(
+                            messages.getString("error.undeploy.fail"),
+                            file.getPath()));
+                }
             }
+        } else {
+            if (applications.size() < 1) {
+                log(messages.getString("info.undeploy.serverxml.emptylist"));
+            }
+
+            StringBuilder buffer = new StringBuilder();
+            int size = applications.size();
+
+            for (int i = 0; i < size; i++) {
+                buffer.append(applications.get(i).getLocation());
+                if (i + 1 < size) {
+                    buffer.append(", ");
+                }
+            }
+
+            log(MessageFormat.format(
+                    messages.getString("info.undeploy.serverxml"),
+                    buffer.toString()));
+
+            for (Application application : applications) {
+                if (application == null) {
+                    log(messages.getString("info.deploy.serverxml.nullapp"),
+                            Project.MSG_DEBUG);
+                } else if (application.getLocation() == null
+                        || application.getLocation().isEmpty()) {
+                    log(messages.getString("info.deploy.serverxml.invalidapp"),
+                            Project.MSG_DEBUG);
+                } else {
+                    // Removing app from the server xml
+                    ServerXml server = new ServerXml(new File(serverConfigRoot,
+                            "/server.xml"));
+                    server.removeApplication(application);
+
+                    // Verifying the removed application in the console log
+                    String stopMessage = null;
+
+                    if (application.getName() != null
+                            && !application.getName().isEmpty()) {
+                        stopMessage = STOP_APP_MESSAGE_CODE_REG
+                                + application.getName();
+                    } else {
+                        String applicationName = new File(
+                                application.getLocation()).getName();
+                        applicationName = applicationName.substring(0,
+                                applicationName.length() - 4);
+                        stopMessage = STOP_APP_MESSAGE_CODE_REG
+                                + applicationName;
+                    }
+
+                    if (waitForStringInLog(stopMessage, appStopTimeout,
+                            getLogFile()) == null) {
+                        throw new BuildException(MessageFormat.format(
+                                messages.getString("error.undeploy.fail"),
+                                application.getName()));
+                    }
+                }
+            }
+
         }
+
+    }
+
+    public String getFile() {
+        return fileName;
+    }
+
+    /**
+     * @return the timeout
+     */
+    public String getTimeout() {
+        return timeout;
     }
 
     private List<File> scanFileSets() throws BuildException {
@@ -69,7 +175,9 @@ public class UndeployTask extends AbstractTask {
             if (fileUndeploy.exists()) {
                 list.add(fileUndeploy);
             } else {
-                throw new BuildException(MessageFormat.format(messages.getString("error.undeploy.file.noexist"), fileUndeploy.getPath()));
+                throw new BuildException(MessageFormat.format(
+                        messages.getString("error.undeploy.file.noexist"),
+                        fileUndeploy.getPath()));
             }
         } else {
             FileSet dropins = new FileSet();
@@ -80,12 +188,14 @@ public class UndeployTask extends AbstractTask {
                 dropins.appendExcludes(pattern.getExcludePatterns(getProject()));
             }
 
-            final DirectoryScanner ds = dropins.getDirectoryScanner(getProject());
+            final DirectoryScanner ds = dropins
+                    .getDirectoryScanner(getProject());
             ds.scan();
             final String[] names = ds.getIncludedFiles();
 
             if (names.length == 0) {
-                throw new BuildException(messages.getString("error.undeploy.fileset.invalid"));
+                throw new BuildException(
+                        messages.getString("error.undeploy.fileset.invalid"));
             }
 
             for (String element : names) {
@@ -99,26 +209,23 @@ public class UndeployTask extends AbstractTask {
         this.fileName = fileName;
     }
 
-    public String getFile() {
-        return this.fileName;
-    }
-
     /**
-     * @return the timeout
+     * Add a flag to perform the undeploy from the server xml.
+     *
+     * @param undeployFromServerXml
+     *            True if the applications are going to be undeployed from the
+     *            server xml. Otherwise, false.
      */
-    public String getTimeout() {
-        return timeout;
+    public void setFromServerXml(boolean fromServerXml) {
+        this.fromServerXml = fromServerXml;
     }
 
     /**
-     * @param timeout the timeout to set
+     * @param timeout
+     *            the timeout to set
      */
     public void setTimeout(String timeout) {
         this.timeout = timeout;
-    }
-
-    public void addPatternset(PatternSet pattern) {
-        this.pattern=pattern;
     }
 
 }

--- a/src/main/java/net/wasdev/wlp/ant/server/ServerXml.java
+++ b/src/main/java/net/wasdev/wlp/ant/server/ServerXml.java
@@ -1,0 +1,186 @@
+/**
+ * (C) Copyright IBM Corporation 2015.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package net.wasdev.wlp.ant.server;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.transform.TransformerException;
+
+import net.wasdev.wlp.ant.server.types.Application;
+import net.wasdev.wlp.ant.server.types.Application.ApplicationType;
+
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * A class to handle operations over the Liberty server.xml file. This class
+ * provides methods to:
+ * <ul>
+ * <li>Add/remove an application</li>
+ * <li>Get available applications in the server.xml file</li>
+ * </ul>
+ */
+public class ServerXml extends XmlCommons {
+
+    /**
+     * A variable to control the applications in the server.xml
+     */
+    private List<Application> applications = new ArrayList<Application>();
+
+    public ServerXml(File file) {
+        super(file);
+        loadApplications();
+    }
+
+    /**
+     * Add an application to the server xml file. If the provided application
+     * has the same location as any other application in the server xml file
+     * then this method will not add the new application.
+     *
+     * @param application
+     *            An application to add
+     * @throws IllegalArgumentException
+     *             If the application is null
+     */
+    public void addApplication(Application application) {
+
+        if (application == null) {
+            throw new IllegalArgumentException(
+                    "The application cannot be null.");
+        }
+
+        // If the application does not have the same location as any other
+        // application in the server xml then add it
+        if (findNodeByAttribute("application", "location",
+                application.getLocation()) == null) {
+            // Adding the new application
+            applications.add(application);
+
+            addNode(getDocument().getElementsByTagName("server").item(0),
+                    application.toNode(getDocument()));
+            try {
+                save();
+            } catch (TransformerException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public List<Application> getApplications() {
+        return applications;
+    }
+
+    /**
+     * Load all current applications found in the server.xml file into a list.
+     */
+    private final void loadApplications() {
+
+        NodeList applications = getDocument().getElementsByTagName(
+                "application");
+
+        for (int i = 0; i < applications.getLength(); i++) {
+            if (!applications.item(i).hasAttributes()) {
+                break; // No attributes are defined , so don't do anything else
+            }
+
+            NamedNodeMap attributes = applications.item(i).getAttributes();
+
+            if (attributes.getNamedItem("location") != null) {
+                Application application = new Application(attributes
+                        .getNamedItem("location").getNodeValue());
+
+                if (attributes.getNamedItem("context-root") != null) {
+                    application.setContextRoot(attributes.getNamedItem(
+                            "context-root").getNodeValue());
+                }
+
+                if (attributes.getNamedItem("id") != null) {
+                    application.setId(attributes.getNamedItem("id")
+                            .getNodeValue());
+                }
+
+                if (attributes.getNamedItem("location") != null) {
+                    application.setLocation(attributes.getNamedItem("location")
+                            .getNodeValue());
+                }
+
+                if (attributes.getNamedItem("name") != null) {
+                    application.setName(attributes.getNamedItem("name")
+                            .getNodeValue());
+                }
+
+                if (attributes.getNamedItem("type") != null) {
+                    ApplicationType type;
+
+                    if (attributes.getNamedItem("type").getNodeValue()
+                            .equals("ear")) {
+                        type = ApplicationType.ear;
+                    } else if (attributes.getNamedItem("type").getNodeValue()
+                            .equals("eba")) {
+                        type = ApplicationType.eba;
+                    } else if (attributes.getNamedItem("type").getNodeValue()
+                            .equals("war")) {
+                        type = ApplicationType.war;
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Application type not supported.");
+                    }
+
+                    application.setType(type);
+                }
+
+                this.applications.add(application);
+            }
+
+        }
+
+    }
+
+    /**
+     * Remove the exact application that represents the Application object from
+     * the server.xml file. If the application is not found then no changes are
+     * performed.
+     *
+     * @param application
+     *            An application to remove
+     */
+    public void removeApplication(Application application) {
+
+        if (application == null) {
+            throw new IllegalArgumentException(
+                    "The application cannot be null.");
+        }
+
+        // Looking for the node in the xml file
+        Node node = findNode(application.toNode(getDocument()));
+
+        // If node was not found then is not removed
+        if (node != null) {
+            removeNode(node);
+            try {
+                save(); // Removed and updated the server.xml
+                applications.remove(application); // Removed from the list
+            } catch (TransformerException e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/net/wasdev/wlp/ant/server/XmlCommons.java
+++ b/src/main/java/net/wasdev/wlp/ant/server/XmlCommons.java
@@ -1,0 +1,271 @@
+/**
+ * (C) Copyright IBM Corporation 2015.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package net.wasdev.wlp.ant.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ *
+ * A class to handle operations with xml files. The class contains methods to:
+ * <ul>
+ * <li>Load in memory an xml file.</li>
+ * <li>Search a node.</li>
+ * <li>Remove a node.</li>
+ * <li>Add a node.</li>
+ * <li>Save modifications in memory to the original xml file.</li>
+ * </ul>
+ *
+ */
+public class XmlCommons {
+    /**
+     * A variable to store the xml file
+     */
+    private File file;
+
+    /**
+     * The document representation of the xml file
+     */
+    private Document document;
+
+    /**
+     * Public constructor that loads by default the xml file.
+     *
+     * @param file
+     *            The xml file to manage.
+     * @throws IllegalArgumentException
+     *             If the file is a directory
+     */
+    public XmlCommons(File file) {
+
+        if (!file.exists()) {
+            throw new IllegalArgumentException(
+                    "The specified file does not exists.");
+        }
+
+        if (file.isDirectory()) {
+            throw new IllegalArgumentException(
+                    "The file cannot be a directory.");
+        }
+
+        try {
+            if (Files.probeContentType(file.toPath()) == null
+                    || !(Files.probeContentType(file.toPath()).equals(
+                            "text/xml") || Files
+                            .probeContentType(file.toPath()).equals(
+                                    "application/xml"))) {
+                throw new IllegalArgumentException(
+                        "The file is not a valid xml file.");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        this.file = file;
+        load();
+    }
+
+    /**
+     * Add a node to the DOM document.
+     *
+     * @param parent
+     *            A parent node
+     * @param child
+     *            A child node to be added into the parent
+     * @throws IllegalArgumentException
+     *             If one of the parameters are null
+     */
+    public void addNode(Node parent, Node child) {
+        if (parent == null || child == null) {
+            throw new IllegalArgumentException(
+                    "None of the parameters should be null.");
+        }
+
+        Node currentNode = parent.appendChild(child);
+        Node previousSibling = currentNode.getPreviousSibling();
+        // Removing text node from the removed node
+        if (previousSibling != null
+                && previousSibling.getNodeType() == Node.TEXT_NODE
+                && previousSibling.getNodeValue().trim().length() == 0) {
+            previousSibling.getParentNode().removeChild(previousSibling);
+        }
+
+    }
+
+    /**
+     * Find and retrieve the first node that is equal as the specified in the
+     * parameter.
+     *
+     * @param node
+     *            A node to compare.
+     * @return The reference to the node that is equal. Otherwise a null object.
+     */
+    public Node findNode(Node node) {
+        NodeList nodes = document.getElementsByTagName(node.getNodeName());
+
+        if (nodes.getLength() > 0) {
+            for (int i = 0; i < nodes.getLength(); i++) {
+
+                if (nodes.item(i).isEqualNode(node)) {
+                    return node;
+                }
+            }
+        }
+        return null;
+
+    }
+
+    /**
+     * Find and retrieve the first node that has the same value of the specified
+     * parameters.
+     *
+     * @param tag
+     *            The xml tag where the node can be found.
+     * @param attribute
+     *            An attribute of the tag.
+     * @param value
+     *            The value of the attribute to be compared with the node.
+     * @return The node that meet the specified criteria. Otherwise a null
+     *         object.
+     */
+    public Node findNodeByAttribute(String tag, String attribute, String value) {
+
+        NodeList nodes = document.getElementsByTagName(tag);
+
+        if (nodes.getLength() > 0) {
+            for (int i = 0; i < nodes.getLength(); i++) {
+
+                NamedNodeMap attributes = nodes.item(i).getAttributes();
+
+                if (attributes.getNamedItem(attribute).getNodeValue()
+                        .equals(value)) {
+                    return nodes.item(i);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the current document that represents the xml file.
+     *
+     * @return The document object from the xml file
+     */
+    public Document getDocument() {
+        return document;
+    }
+
+    /**
+     * Load and store a DOM representation of the xml file.
+     *
+     * @throws IOException
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     */
+    private void load() {
+        try {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            document = documentBuilder.parse(file);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Remove a node of the DOM document. If the specified node is not found
+     * then nothing is removed.
+     *
+     * @param node
+     *            An identical node to the node to be removed from the DOM
+     *            document.
+     * @throws IllegalArgumentException
+     *             If the node is null
+     */
+    public void removeNode(Node node) {
+        if (node == null) {
+            throw new IllegalArgumentException("The node cannot be null.");
+        }
+
+        NodeList nodes = document.getElementsByTagName(node.getNodeName());
+
+        if (nodes.getLength() > 0) {
+            for (int i = 0; i < nodes.getLength(); i++) {
+
+                if (nodes.item(i).isEqualNode(node)) {
+                    Node previousSibling = nodes.item(i).getPreviousSibling();
+
+                    // Removing node from the DOM
+                    nodes.item(i).getParentNode().removeChild(nodes.item(i));
+
+                    // Removing text node from the removed node
+                    if (previousSibling != null
+                            && previousSibling.getNodeType() == Node.TEXT_NODE
+                            && previousSibling.getNodeValue().trim().length() == 0) {
+                        previousSibling.getParentNode().removeChild(
+                                previousSibling);
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * This method save the changes in the DOM document to the specified file
+     * when the object was created.
+     *
+     * @throws TransformerException
+     */
+    public void save() throws TransformerException {
+
+        TransformerFactory transformerFactory = TransformerFactory
+                .newInstance();
+
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(
+                "{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
+        StreamResult streamResult = new StreamResult(file);
+
+        transformer.transform(domSource, streamResult);
+    }
+
+}

--- a/src/main/java/net/wasdev/wlp/ant/server/types/Application.java
+++ b/src/main/java/net/wasdev/wlp/ant/server/types/Application.java
@@ -1,0 +1,229 @@
+/**
+ * (C) Copyright IBM Corporation 2015.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package net.wasdev.wlp.ant.server.types;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * An abstract representation of an application node from the server.xml
+ */
+public class Application {
+
+    /**
+     * A public enum with supported application types.
+     */
+    public enum ApplicationType {
+        /**
+         * An Enterprise Archive.
+         */
+        ear,
+
+        /**
+         * A Web Application Archive.
+         */
+        war,
+
+        /**
+         * An Enterprise Bundle Archive.
+         */
+        eba;
+    }
+
+    private String id;
+
+    private String location;
+    private String name;
+    private ApplicationType type;
+    private String contextRoot;
+
+    /**
+     * Instantiate a new application with a defined location.
+     *
+     * @param location
+     *            The path to the application.
+     */
+    public Application(String location) {
+        this.location = location;
+    }
+
+    /**
+     * Instantiate a new application with null fields.
+     */
+    @Deprecated
+    public Application() {
+        //This constructor is used to keep compatibility with ant
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Application)) {
+            return false;
+        }
+        Application other = (Application) obj;
+        if (contextRoot == null) {
+            if (other.contextRoot != null) {
+                return false;
+            }
+        } else if (!contextRoot.equals(other.contextRoot)) {
+            return false;
+        }
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        if (location == null) {
+            if (other.location != null) {
+                return false;
+            }
+        } else if (!location.equals(other.location)) {
+            return false;
+        }
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        if (type != other.type) {
+            return false;
+        }
+        return true;
+    }
+
+    public String getContextRoot() {
+        return contextRoot;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ApplicationType getType() {
+        return type;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + (contextRoot == null ? 0 : contextRoot.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
+        result = prime * result + (location == null ? 0 : location.hashCode());
+        result = prime * result + (name == null ? 0 : name.hashCode());
+        result = prime * result + (type == null ? 0 : type.hashCode());
+        return result;
+    }
+
+    public void setContextRoot(String contextRoot) {
+        this.contextRoot = contextRoot;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setLocation(String location) {
+        if (location != null && !location.isEmpty()) {
+            this.location = location;
+        }
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setType(ApplicationType type) {
+        this.type = type;
+    }
+
+    /**
+     * This method constructs a DOM node that represents the server application.
+     *
+     * @param document
+     *            The Document where this node will belong.
+     * @return A DOM node. If the method cannot construct the node then return a
+     *         null object.
+     */
+    public Node toNode(Document document) {
+        Element element = document.createElement("application");
+        List<Attr> attibutesList = new ArrayList<Attr>();
+
+        Map<String, String> attributes = new HashMap<String, String>();
+
+        attributes.put("context-root", contextRoot);
+        attributes.put("id", id);
+        attributes.put("location", location);
+        attributes.put("name", name);
+
+        if (type != null) {
+            attributes.put("type", type.toString());
+        }
+
+        for (String key : attributes.keySet()) {
+
+            // If the attribute is null or is not set then is not necessary to
+            // add it
+            if (attributes.get(key) != null && !attributes.get(key).isEmpty()) {
+
+                Attr attribute = document.createAttribute(key);
+                attribute.setValue(attributes.get(key));
+                attibutesList.add(attribute);
+            }
+        }
+
+        for (Attr attribute : attibutesList) {
+            element.setAttributeNode(attribute);
+        }
+
+        return element;
+    }
+
+}

--- a/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
+++ b/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
@@ -102,6 +102,30 @@ error.deploy.file.isdirectory=CWWKM2026E: The file parameter is a directory, the
 error.deploy.file.isdirectory.explanation=The deploy task cannot deploy the application as the file parameter is a directory.
 error.deploy.file.isdirectory.useraction=Correct the value of the file parameter.
 
-error.parameter.invalid=CWWKM2027E: The {0} parameter is empty.
-error.parameter.invalid.explanation=The {0} parameter is empty.
-error.parameter.invalid.useraction=Correct the value of the file parameter.
+error.parameter.invalid=CWWKM2027E: The {0} parameter is empty or null.
+error.parameter.invalid.explanation=The {0} parameter cannot be empty or null.
+error.parameter.invalid.useraction=Provide a non empty or null parameter
+
+info.deploy.serverxml.emptylist=CWWKM2028I: No applications to deploy.
+info.deploy.serverxml.emptylist.explanation=One or more applications should be defined to perform the deploy to the server xml.
+info.deploy.serverxml.emptylist.useraction=No action is required.
+
+info.deploy.serverxml.nullapp=CWWKM2029I: Skipping null application.
+info.deploy.serverxml.nullapp.explanation=A null application has been found and will be skipped.
+info.deploy.serverxml.nullapp.useraction=No action is required.
+
+info.deploy.serverxml.invalidapp=CWWKM2030I: Skipping invalid application.
+info.deploy.serverxml.invalidapp.explanation=The location attribute in the application is null or empty.
+info.deploy.serverxml.invalidapp.useraction=No action is required.
+
+info.undeploy.serverxml.emptylist=CWWKM2031I: No applications to undeploy.
+info.undeploy.serverxml.emptylist.explanation=One or more applications should be defined to perform the undeploy from the server xml.
+info.undeploy.serverxml.emptylist.useraction=No action is required.
+
+info.deploy.serverxml=CWWKM2032I: Deploying application(s) {0} to the server.xml file.
+info.deploy.serverxml.explanation=One or more applications are being deployed.
+info.deploy.serverxml.useraction=No action is required.
+
+info.undeploy.serverxml=CWWKM2033I: Undeploying application(s) {0} from the server.xml file.
+info.undeploy.serverxml.explanation=One or more applications are being undeployed.
+info.undeploy.serverxml.useraction=No action is required.

--- a/src/main/resources/net/wasdev/wlp/ant/antlib.xml
+++ b/src/main/resources/net/wasdev/wlp/ant/antlib.xml
@@ -6,5 +6,7 @@
     <taskdef classname="net.wasdev.wlp.ant.UndeployTask" name="undeploy"/>
     <taskdef classname="net.wasdev.wlp.ant.InstallFeatureTask" name="install-feature" />
     <taskdef classname="net.wasdev.wlp.ant.install.InstallLibertyTask" name="install-liberty" />
+
+    <!-- Nested types -->
+    <typedef classname="net.wasdev.wlp.ant.server.types.Application" name="application"/>
 </antlib>
-	

--- a/src/test/java/net/wasdev/wlp/ant/server/ServerXmlTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/server/ServerXmlTest.java
@@ -1,0 +1,151 @@
+package net.wasdev.wlp.ant.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import net.wasdev.wlp.ant.server.types.Application;
+import net.wasdev.wlp.ant.server.types.Application.ApplicationType;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+public class ServerXmlTest {
+
+    /**
+     * A sample server xml file.
+     */
+    private final File serverXmlFile = new File(getClass().getClassLoader()
+            .getResource("sample_server.xml").getFile());
+
+    /**
+     * A variable to define a temporary server xml for modications.
+     */
+    private File tmpServerXml = null;
+
+    /**
+     * Assign a temporary server xml file to perform modifications without
+     * modifying the original.
+     */
+    @Before
+    public void setUp() {
+        try {
+            tmpServerXml = Files.createTempFile("tmpServerXml", ".xml")
+                    .toFile();
+            tmpServerXml.deleteOnExit();
+
+            Files.copy(serverXmlFile.toPath(), tmpServerXml.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Test if the add application method throw an exception if the application
+     * parameter is null.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testThatAddApplicationThrowsExceptionIfApplicationIsNull() {
+        Application nullApplication = null;
+
+        ServerXml server = new ServerXml(tmpServerXml);
+        server.addApplication(nullApplication);
+    }
+
+    /**
+     * Test if adds a new application.
+     */
+    @Test
+    public void testThatAddsApplication() {
+        try {
+            Application newApplication = new Application(
+                    "C:\\NewApplication.war");
+
+            // Adding the application to the server.xml
+            ServerXml server = new ServerXml(tmpServerXml);
+            server.addApplication(newApplication);
+
+            Assert.assertEquals(
+                    "Failure while trying to add the application to the list of applications.",
+                    4, server.getApplications().size());
+
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(tmpServerXml);
+
+            Assert.assertEquals(
+                    "Failure while trying to add the application to the server.xml.",
+                    4, document.getElementsByTagName("application").getLength());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Test if the default constructor load the applications.
+     */
+    @Test
+    public void testThatApplicationsAreLoadedByConstructor() {
+        ServerXml server = new ServerXml(tmpServerXml);
+
+        Assert.assertEquals(
+                "The default constructor  does not load the applications", 3,
+                server.getApplications().size());
+
+    }
+
+    /**
+     * Test if the remove application method throw an exception if the
+     * application parameter is null.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testThatRemoveApplicationThrowsExceptionIfApplicationIsNull() {
+        Application nullApplication = null;
+
+        ServerXml server = new ServerXml(tmpServerXml);
+        server.removeApplication(nullApplication);
+    }
+
+    /**
+     * Test if removes an application.
+     */
+    @Test
+    public void testThatRemovesApplication() {
+        try {
+            Application newApplication = new Application("C:\\DemoEAR.ear");
+            newApplication.setId("12345");
+            newApplication.setType(ApplicationType.ear);
+
+            // Adding the application to the server.xml
+            ServerXml server = new ServerXml(tmpServerXml);
+            server.removeApplication(newApplication);
+
+            Assert.assertEquals(
+                    "Failure while trying to remove the application to the list of applications.",
+                    2, server.getApplications().size());
+
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(tmpServerXml);
+
+            Assert.assertEquals(
+                    "Failure while trying to remove the application to the server.xml.",
+                    2, document.getElementsByTagName("application").getLength());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/test/java/net/wasdev/wlp/ant/server/XmlCommonsTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/server/XmlCommonsTest.java
@@ -1,0 +1,245 @@
+package net.wasdev.wlp.ant.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class XmlCommonsTest {
+
+    /**
+     * A sample xml file.
+     */
+    private final File sampleXmlFile = new File(getClass().getClassLoader()
+            .getResource("sample.xml").getFile());
+
+    /**
+     * Test that the add node method append a node.
+     */
+    @Test
+    public void testThatAddsNode() {
+        try {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.newDocument();
+
+            // Defining new node to add
+            Node nodeToAdd = document.createElement("sampleNode");
+            nodeToAdd.setTextContent("Sample Content");
+
+            // Adding the node as a child of the DOM document
+            XmlCommons xml = new XmlCommons(sampleXmlFile);
+            xml.addNode(xml.getDocument().getDocumentElement(), xml
+                    .getDocument().importNode(nodeToAdd, true));
+
+            // Saving the modification to the DOM document to a temporary
+            // DOM document to verify the changes.
+            TransformerFactory transformerFactory = TransformerFactory
+                    .newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+
+            DOMSource domSource = new DOMSource(xml.getDocument());
+            DOMResult domResult = new DOMResult();
+
+            transformer.transform(domSource, domResult);
+
+            document = (Document) domResult.getNode();
+
+            Assert.assertEquals("Add function hasn't added the node.", 1,
+                    document.getElementsByTagName("sampleNode").getLength());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Test if the constructor throws an {@link IllegalArgumentException}
+     * whether the file parameter is a directory.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testThatConstructorThrowsIllegalArgumentExceptionIfDirectory() {
+        XmlCommons xml = new XmlCommons(new File(getClass().getClassLoader()
+                .getResource("").getPath()));
+    }
+
+    /**
+     * Test if the constructor throws an {@link IllegalArgumentException}
+     * whether the file parameter is not a valid xml file.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testThatConstructorThrowsIllegalArgumentExceptionIfNotXml() {
+        try {
+            File tmpFile = Files.createTempFile("tmpFile", ".tmp").toFile();
+            tmpFile.deleteOnExit();
+            XmlCommons xml = new XmlCommons(tmpFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Test whether the constructor load the xml file in a document object.
+     */
+    @Test
+    public void testThatDocumentIsLoaded() {
+        XmlCommons xml = new XmlCommons(sampleXmlFile);
+        Assert.assertNotNull(xml.getDocument());
+    }
+
+    /**
+     * Test if a node is found in an xml file by a key attribute.
+     */
+    @Test
+    public void testThatFindsNodeByKeyAttribute() {
+        try {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(sampleXmlFile);
+
+            // Expecting catalog_item node with key attribute "Men's"
+            Node expectedNode = document.getElementsByTagName("catalog_item")
+                    .item(0);
+
+            XmlCommons xml = new XmlCommons(sampleXmlFile);
+
+            Assert.assertTrue("The node function has not found the node.",
+                    expectedNode.isEqualNode(xml.findNodeByAttribute(
+                            "catalog_item", "gender", "Men's")));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    /**
+     * Test if a node is found in an xml file when a node is provided.
+     */
+    @Test
+    public void testThatFindsNodeByProvidingNode() {
+        try {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(sampleXmlFile);
+
+            // Expecting node with item number = RRX9856
+            Node expectedNode = document.getElementsByTagName("item_number")
+                    .item(1);
+
+            // Defining the node to find
+            Node nodeToFind = document.createElement("item_number");
+            nodeToFind.setTextContent("RRX9856");
+
+            XmlCommons xml = new XmlCommons(sampleXmlFile);
+
+            Assert.assertTrue("The node function has not found the node.",
+                    expectedNode.isEqualNode(xml.findNode(nodeToFind)));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    /**
+     * Test that a node is removed from the DOM document in memory.
+     */
+    @Test
+    public void testThatRemovesNode() {
+        try {
+
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(sampleXmlFile);
+
+            NodeList nodes = document.getElementsByTagName("catalog_item");
+
+            XmlCommons xml = new XmlCommons(sampleXmlFile);
+            xml.removeNode(nodes.item(1));
+
+            // Saving the modification to the DOM document to a temporary
+            // DOM document to verify the changes.
+            TransformerFactory transformerFactory = TransformerFactory
+                    .newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+
+            DOMSource domSource = new DOMSource(xml.getDocument());
+            DOMResult domResult = new DOMResult();
+
+            transformer.transform(domSource, domResult);
+
+            document = (Document) domResult.getNode();
+
+            Assert.assertEquals(
+                    "removeNode method has failed while removing a node.", 1,
+                    document.getElementsByTagName("catalog_item").getLength());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Test if the save function save the performed changes over the xml file.
+     */
+    @Test
+    public void testThatSavesChanges() {
+        try {
+            File tmpXml = Files.createTempFile("tmpXml", ".xml").toFile();
+            tmpXml.deleteOnExit();
+
+            Files.copy(sampleXmlFile.toPath(), tmpXml.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.newDocument();
+
+            // Defining new node to add
+            Node nodeToAdd = document.createElement("sampleNode");
+            nodeToAdd.setTextContent("Sample Content");
+
+            // Modifying and saving
+            XmlCommons xml = new XmlCommons(tmpXml);
+            xml.addNode(xml.getDocument().getDocumentElement(), xml
+                    .getDocument().importNode(nodeToAdd, true));
+            xml.save();
+
+            document = documentBuilder.parse(tmpXml);
+
+            Assert.assertEquals(
+                    "Changes were not performed by the save function.", 1,
+                    document.getElementsByTagName("sampleNode").getLength());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/src/test/java/net/wasdev/wlp/ant/server/types/ApplicationTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/server/types/ApplicationTest.java
@@ -1,0 +1,70 @@
+package net.wasdev.wlp.ant.server.types;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import net.wasdev.wlp.ant.server.types.Application.ApplicationType;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class ApplicationTest {
+
+    /**
+     * An empty DOM Document to define Nodes and Elements.
+     */
+    private static Document document;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        try {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
+                    .newInstance();
+            DocumentBuilder documentBuilder;
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            document = documentBuilder.newDocument();
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    /**
+     * Test when two applications are equals with the same fields.
+     */
+    @Test
+    public void testThatApplicationEqualsApplication() {
+        Application application1 = new Application("C:\\sample.war");
+        application1.setName("WebApp");
+
+        Application application2 = new Application("C:\\sample.war");
+        application2.setName("WebApp");
+
+        Assert.assertEquals("Equals method is not working.", application1,
+                application2);
+    }
+
+    /**
+     * Test if a predefined application return an expected node.
+     */
+    @Test
+    public void testThatApplicationToNodeReturnNode() {
+        Application sampleApplication = new Application("C:\\sample.war");
+        sampleApplication.setName("WebApp");
+        sampleApplication.setType(ApplicationType.war);
+
+        // An element is a kind of DOM node.
+        Element expectedNode = document.createElement("application");
+        expectedNode.setAttribute("name", "WebApp");
+        expectedNode.setAttribute("location", "C:\\sample.war");
+        expectedNode.setAttribute("type", "war");
+
+        Assert.assertTrue("The application do not return the expected node.",
+                expectedNode.isEqualNode(sampleApplication.toNode(document)));
+    }
+
+}

--- a/src/test/resources/sample.xml
+++ b/src/test/resources/sample.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<catalog>
+   <product description="Cardigan Sweater" product_image="cardigan.jpg">
+      <catalog_item gender="Men's">
+         <item_number>QWZ5671</item_number>
+         <price>39.95</price>
+         <size description="Medium">
+            <color_swatch image="red_cardigan.jpg">Red</color_swatch>
+            <color_swatch image="burgundy_cardigan.jpg">Burgundy</color_swatch>
+         </size>
+         <size description="Large">
+            <color_swatch image="red_cardigan.jpg">Red</color_swatch>
+            <color_swatch image="burgundy_cardigan.jpg">Burgundy</color_swatch>
+         </size>
+      </catalog_item>
+      <catalog_item gender="Women's">
+         <item_number>RRX9856</item_number>
+         <price>42.50</price>
+         <size description="Small">
+            <color_swatch image="red_cardigan.jpg">Red</color_swatch>
+            <color_swatch image="navy_cardigan.jpg">Navy</color_swatch>
+            <color_swatch image="burgundy_cardigan.jpg">Burgundy</color_swatch>
+         </size>
+         <size description="Medium">
+            <color_swatch image="red_cardigan.jpg">Red</color_swatch>
+            <color_swatch image="navy_cardigan.jpg">Navy</color_swatch>
+            <color_swatch image="burgundy_cardigan.jpg">Burgundy</color_swatch>
+            <color_swatch image="black_cardigan.jpg">Black</color_swatch>
+         </size>
+         <size description="Large">
+            <color_swatch image="navy_cardigan.jpg">Navy</color_swatch>
+            <color_swatch image="black_cardigan.jpg">Black</color_swatch>
+         </size>
+         <size description="Extra Large">
+            <color_swatch image="burgundy_cardigan.jpg">Burgundy</color_swatch>
+            <color_swatch image="black_cardigan.jpg">Black</color_swatch>
+         </size>
+      </catalog_item>
+   </product>
+</catalog>

--- a/src/test/resources/sample_server.xml
+++ b/src/test/resources/sample_server.xml
@@ -1,0 +1,19 @@
+<server description="new server">
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>wab-1.0</feature>
+    	<feature>ejbLite-3.2</feature>
+		<feature>osgiAppIntegration-1.0</feature>
+	</featureManager>
+    
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint"/>
+    <applicationMonitor updateTrigger="mbean"/>
+    
+    <application location="C:\test-eba.eba"/>
+    <application location="C:\sample.war" name="SampleWar"/>
+    <application location="C:\DemoEAR.ear" id="12345" type="ear"/>
+    
+</server>


### PR DESCRIPTION
General changes:
- Added new package net.wasdev.wlp.ant.server to organize classes that
control the server xml file
- Added XmlCommons class to manage an xml file
- Added ServerXml class to manage the server xml file.
- Added new package net.wasdev.wlp.ant.server.types to organize new data
types to control the server xml file
- Added Application class that defines an application from the server
xml
- Added unitary tests for XmlCommons, ServerXml and Application classes.
- Added sample.xml, sample_server.xml files as resources for the unitary tests.

Changes to antlib.xml
- Added an entry to define a nested element called Application.

Changes to DeployTask:
- Added support to deploy in the server xml

Changes to UndeployTask:
-Added support for undeploy an application from the server xml

Changes to AntMessages.properties
- Modified error.parameter.invalid message because the purpose of that
message should be generic.
- Added info.deploy.serverxml.emptylist message to tell the user that
nothing were deployed.
- Added info.deploy.serverxml.nullapp message to tell the user that the
application to deploy/undeploy is null.
- Added info.deploy.serverxml.invalidapp to tell the user that the
application to deploy/undeploy is invalid because it does not have the
location attribute.
- Added info.undeploy.serverxml.emptylist message to tell the user that
nothing were undeployed.

Changes to README.md:
- Added deploy/undeploy examples.