### PR TITLE
Fixes issue #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *~
 target/
+.project
+.settings
+.classpath
+.factorypath

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The `deploy` task supports deployment of one or more applications to the Liberty
 | --------- | ------------ | ----------|
 | installDir | Location of the Liberty profile server installation. | Yes |
 | serverName | Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
-| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
+| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
 | outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
 | file | Location of a single application to be deployed. See [file attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). The application type can be war, ear, rar, eba, zip , or jar. | Yes, only when the `fileset` attribute is not specified. |
 | fileset | Location of multiple applications to be deployed. See [fileset attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). | Yes, only when the `file` attribute is not specified.|
@@ -156,7 +156,7 @@ The `undeploy` task supports undeployment of a single application from the Liber
 | --------- | ------------ | ----------|
 | installDir | Location of the Liberty profile server installation. | Yes |
 | serverName | Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
-| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
+| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
 | outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
 | file | Name of the application to be undeployed. The application type can be war, ear, rar, eba, zip , or jar. | No |
 | patternset | Includes and excludes patterns of applications to be undeployed. See [patternset attribute in Apache Ant](http://ant.apache.org/manual/Types/patternset.html). | No |
@@ -191,7 +191,7 @@ The `install-feature` task installs a feature packaged as a Subsystem Archive (E
 | --------- | ------------ | ----------|
 | installDir | Location of the Liberty profile server installation. | Yes |
 | serverName | Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
-| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
+| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
 | outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
 | acceptLicense | Accept feature license terms and conditions. The default value is `false`. | No |
 | whenFileExits | Specifies the action to take if a file to be installed already exits. Use `fail` to abort the installation, `ignore` to continue the installation and ignore the file that exists, and `replace` to overwrite the existing file. | No | 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,27 @@ The `server` task supports the following operations:
 
 #### Examples
 
-    <wlp:server id="wlp.ant.test" installDir="${wlp_install_dir}" operation="start" 
-            serverName="${serverName}" userDir="${wlp_usr}" outputDir="${wlp_output}" />
+1- Set the operation in the task where is being used the "ref" atribute.
 
-    <wlp:server ref="wlp.ant.test" operation="status"/>
+```
+<!-- In the following example is defined a server configuration reference 
+     and is executed the "status" operation only. -->
 
+<wlp:server id="idMyServer" installDir="${wlp_install_dir}" 
+userDir="${wlp_usr}" outputDir="${wlp_output}" serverName="${serverName}"/>
 
+<wlp:server ref="idMyServer" operation="status"/>
+```
+
+2- Optionally could be set an operation in the server configuration, in this way if the second task also contains an operation set, both operations are executed.
+```
+<!-- In the following example is defined an operation in the server configuration reference and then another one is set up in the second task both are executed. -->
+
+<wlp:server id="idMyServer" installDir="${wlp_install_dir}" 
+userDir="${wlp_usr}" outputDir="${wlp_output}" serverName="${serverName}" operation="status"/>
+
+<wlp:server ref="idMyServer" operation="start"/>
+```
 ### deploy task
 ---
 

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014.
+ * (C) Copyright IBM Corporation 2014, 2015.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,39 +75,44 @@ public class ServerTask extends AbstractTask {
 
     @Override
     public void execute() {
-        if (operation == null || operation.length() <= 0) {
-            throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "operation"));
-        }
 
         initTask();
 
-        try {
-            if ("create".equals(operation)) {
-                doCreate();
-            } else if ("run".equals(operation)) {
-                doRun();
-            } else if ("start".equals(operation)) {
-                doStart();
-            } else if ("stop".equals(operation)) {
-                doStop();
-            } else if ("status".equals(operation)) {
-                doStatus();
-            } else if ("debug".equals(operation)) {
-                // Debug seems useless in ant tasks, but still keep it.
-                doDebug();
-            } else if ("package".equals(operation)) {
-                doPackage();
-            } else if ("dump".equals(operation)) {
-                doDump();
-            } else if ("javadump".equals(operation)) {
-                doJavaDump();
-            } else {
-                throw new BuildException("Unsupported operation: " + operation);
+        if(getRuntimeConfigurableWrapper().getAttributeMap().get("id") == null) {
+            if ((operation == null || operation.length() <= 0)) {
+                throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "operation"));
             }
-        } catch (BuildException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new BuildException(e);
+        }
+
+        if (operation != null) {
+            try {
+              if ("create".equals(operation)) {
+                  doCreate();
+              } else if ("run".equals(operation)) {
+                  doRun();
+              } else if ("start".equals(operation)) {
+                  doStart();
+              } else if ("stop".equals(operation)) {
+                  doStop();
+              } else if ("status".equals(operation)) {
+                  doStatus();
+              } else if ("debug".equals(operation)) {
+                  // Debug seems useless in ant tasks, but still keep it.
+                  doDebug();
+              } else if ("package".equals(operation)) {
+                  doPackage();
+              } else if ("dump".equals(operation)) {
+                  doDump();
+              } else if ("javadump".equals(operation)) {
+                  doJavaDump();
+              } else {
+                  throw new BuildException("Unsupported operation: " + operation);
+              }
+          } catch (BuildException e) {
+              throw e;
+          } catch (Exception e) {
+              throw new BuildException(e);
+          }
         }
     }
         
@@ -336,5 +341,5 @@ public class ServerTask extends AbstractTask {
     public void setTemplate(String template) {
         this.template = template;
     }
-            
+
 }


### PR DESCRIPTION
Hi guys, this should fix issue 18. 
Basically allow to the user set a server configuration and assign and id without have to set an operation.
If the task where is being used the "ref" attribute doesn't have set an operation throw a build exception.
If there is anything else to do, please let me know.