### PR TITLE
Recongize when outputDir and userDir are set to non-existent directory

### DIFF
--- a/src/main/java/net/wasdev/wlp/ant/DeployTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/DeployTask.java
@@ -55,7 +55,7 @@ public class DeployTask extends AbstractTask {
             appStartTimeout = Long.valueOf(timeout);
         }
 
-        File dropInFolder = new File(serverConfigRoot, "dropins");
+        File dropInFolder = new File(serverConfigDir, "dropins");
         for (File file : files) {
             File destFile = new File(dropInFolder, file.getName());
             log(MessageFormat.format(messages.getString("info.deploy.app"), file.getPath()));

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -121,7 +121,7 @@ public class ServerTask extends AbstractTask {
         
     private void doStart() throws Exception {
         // create server first if it doesn't exist        
-        if (!serverConfigRoot.exists()) {
+        if (!serverConfigDir.exists()) {
             log(MessageFormat.format(messages.getString("info.server.create"), serverName));
             doCreate();
         }
@@ -166,7 +166,7 @@ public class ServerTask extends AbstractTask {
     
     private void doRun() throws Exception {
         // create server first if it doesn't exist        
-        if (!serverConfigRoot.exists()) {
+        if (!serverConfigDir.exists()) {
             log(MessageFormat.format(messages.getString("info.server.create"), serverName));
             doCreate();
         }

--- a/src/main/java/net/wasdev/wlp/ant/UndeployTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/UndeployTask.java
@@ -62,7 +62,7 @@ public class UndeployTask extends AbstractTask {
     }
 
     private List<File> scanFileSets() throws BuildException {
-        File dropinsDir = new File(serverConfigRoot, "dropins");
+        File dropinsDir = new File(serverConfigDir, "dropins");
         final List<File> list = new ArrayList<File>();
 
         if (fileName != null) {


### PR DESCRIPTION
If outputDir is set to non-existent directory, Liberty runtime will create it automatically. Same with userDir. Make sure Ant tasks respect that.
