### PR TITLE
#25 --os attribute added to package-server task

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ The `server` task supports the following operations:
 | operation | Server operations available as options: `create`, `start`, `stop`, `status`, `package`, `dump`, and `javadump`. | Yes | 
 | clean | Clean all cached information on server start up. The default value is `false`. Only used with the `start` operation. | No | 
 | timeout | Waiting time before the server starts. The default value is 30 seconds. The unit is milliseconds. Only used with the `start` operation. | No | 
-| include | A comma-delimited list of values. The valid values vary depending on the operation. For the `package` operation the valid values are `all`, `usr`, and `minify`. For the `dump` operation the valid values are `heap`, `system`, and `thread`. For the `javadump` operation the valid values are `heap` and `system`. | No. |
+| include | A comma-delimited list of values. The valid values vary depending on the operation. For the `package` operation the valid values are `all`, `usr`, and `minify`. For the `dump` operation the valid values are `heap`, `system`, and `thread`. For the `javadump` operation the valid values are `heap` and `system`. | Yes, only when the `os` option is set. |
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
-| os| Specifies the operating systems that you want the packaged server to support. Supply a comma-separated list. Only used with the `package` operation and the 'include' option must be 'minify'. | No |
+| os| A comma-delimited list of operating systems that you want the packaged server to support. Only used with the `package` operation and the 'include' option must be set to 'minify'. | No |
 | ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. | No | 
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The `server` task supports the following operations:
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
+| os| Specifies the operating systems that you want the packaged server to support. Supply a comma-separated list. Only used with the `package` operation and the 'include' option must be 'minify'. | No |
 | ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. | No | 
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ The `server` task supports the following operations:
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
 | os| A comma-delimited list of operating systems that you want the packaged server to support. Only used with the `package` operation and the 'include' option must be set to 'minify'. | No |
-| ref | Reference to an existing server task definition to reuse its server configuration. The value can be null when other required attributes are set. | No | 
 
 #### Examples
 

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -61,6 +61,7 @@
         <wlp:server ref="testServer" operation="stop" />
         <wlp:uninstall-feature ref="testServer" name="mongodb-2.0"/>
         <wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.zip" />
+        <wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.os.zip" include="minify" os="OS/400,-z/OS"/>
     </target>
 
 </project>

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -281,12 +281,6 @@ public class ServerTask extends AbstractTask {
     
     private void addOsOption(List<String> command) {
         if (os != null) {
-        	if(include == null){
-        		throw new BuildException("In order to use the 'os' option, the 'include' attribute must be set with the value 'minify'.");
-        	}
-        	if(!include.equals("minify")) {
-        		throw new BuildException("The 'os' option can only be used when the 'include' attribute is 'minify' and it's: '" + include + "'.");
-        	}
             command.add("--os=" + os);
         }
     }

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -281,8 +281,11 @@ public class ServerTask extends AbstractTask {
     
     private void addOsOption(List<String> command) {
         if (os != null) {
+        	if(include == null){
+        		throw new BuildException("In order to use the 'os' option, the 'include' attribute must be set with the value 'minify'.");
+        	}
         	if(!include.equals("minify")) {
-        		throw new BuildException("The 'os' option can only be used when the include attribute is 'minify' and it's: '" + include + "'");
+        		throw new BuildException("The 'os' option can only be used when the 'include' attribute is 'minify' and it's: '" + include + "'.");
         	}
             command.add("--os=" + os);
         }

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -56,6 +56,9 @@ public class ServerTask extends AbstractTask {
     // used with 'create' operation
     private String template;
     
+    // used with 'package' operation
+    private String os;
+    
     @Override
     protected void initTask() {
         super.initTask();
@@ -233,6 +236,7 @@ public class ServerTask extends AbstractTask {
         List<String> command = getInitialCommand(operation);
         addArchiveOption(command);
         addIncludeOption(command);
+        addOsOption(command);
         processBuilder.command(command);
         Process p = processBuilder.start();
         checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());
@@ -272,6 +276,15 @@ public class ServerTask extends AbstractTask {
                 throw new BuildException("The archive attribute must specify a file");
             }
             command.add("--archive=" + archive);
+        }
+    }
+    
+    private void addOsOption(List<String> command) {
+        if (os != null) {
+        	if(!include.equals("minify")) {
+        		throw new BuildException("The 'os' option can only be used when the include attribute is 'minify' and it's: '" + include + "'");
+        	}
+            command.add("--os=" + os);
         }
     }
     
@@ -315,6 +328,21 @@ public class ServerTask extends AbstractTask {
      */
     public void setArchive(File archive) {
         this.archive = archive;
+    }
+    
+    /**
+     * @return the os
+     */
+    public String getOs() {
+        return os;
+    }
+
+    /**
+     * @param os
+     *            the os to set
+     */
+    public void setOs(String os) {
+        this.os = os;
     }
 
     /**
@@ -376,14 +404,22 @@ public class ServerTask extends AbstractTask {
         // started/stopped is set based on operation.
         // process will return this code if start is called when server is already running
         // or will return this code for stop/status when the server is not running
-        REDUNDANT_ACTION_STATUS(1), SERVER_NOT_EXIST_STATUS(2), SERVER_ACTIVE_STATUS(
-                                                                                     3), SERVER_INACTIVE_STATUS(4),
+        REDUNDANT_ACTION_STATUS(1), 
+        SERVER_NOT_EXIST_STATUS(2), 
+        SERVER_ACTIVE_STATUS(3), 
+        SERVER_INACTIVE_STATUS(4),
         // Jump a few numbers for error return codes-- see readInitialConfig
-        BAD_ARGUMENT(20), ERROR_SERVER_STOP(21), ERROR_SERVER_START(22), LOCATION_EXCEPTION(
-                                                                                            23), LAUNCH_EXCEPTION(24), RUNTIME_EXCEPTION(25), UNKNOWN_EXCEPTION(
-                                                                                                                                                                26),
-        PROCESS_CLIENT_EXCEPTION(27), ERROR_SERVER_PACKAGE(28), ERROR_SERVER_DUMP(
-                                                                                  29), ERROR_SERVER_ATTACH(30);
+        BAD_ARGUMENT(20), 
+        ERROR_SERVER_STOP(21), 
+        ERROR_SERVER_START(22), 
+        LOCATION_EXCEPTION(23), 
+        LAUNCH_EXCEPTION(24), 
+        RUNTIME_EXCEPTION(25), 
+        UNKNOWN_EXCEPTION(26),
+        PROCESS_CLIENT_EXCEPTION(27), 
+        ERROR_SERVER_PACKAGE(28), 
+        ERROR_SERVER_DUMP(29), 
+        ERROR_SERVER_ATTACH(30);
 
         final int val;
 


### PR DESCRIPTION
Changes to README.md:
<ul>
<li>Changed the 'Required' field of <i>include</i> parameter to <b>Yes, only when the `os` option is set</b>.</li>
<li>Added the <i>os</i> attribute to the server task parameters table.</li>
</ul>
Changes to src/it/basic/build.xml:
<ul>
<li>Added a package-os task.</li>
</ul>
Changes to src/main/java/net/wasdev/wlp/ant/ServerTask.java:
<ul>
<li>Added the <i>os</i> attribute along with its getter and setter.</li>
<li>Added the addOsOption method and its use in the doPackage method.</li>
<li>Arranged the ReturnCodes</li>
</ul>
