### PR TITLE
#25 --os attribute added to package-server task

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ The `server` task supports the following operations:
 | operation | Server operations available as options: `create`, `start`, `stop`, `status`, `package`, `dump`, and `javadump`. | Yes | 
 | clean | Clean all cached information on server start up. The default value is `false`. Only used with the `start` operation. | No | 
 | timeout | Waiting time before the server starts. The default value is 30 seconds. The unit is milliseconds. Only used with the `start` operation. | No | 
-| include | A comma-delimited list of values. The valid values vary depending on the operation. For the `package` operation the valid values are `all`, `usr`, and `minify`. For the `dump` operation the valid values are `heap`, `system`, and `thread`. For the `javadump` operation the valid values are `heap` and `system`. | No |
+| include | A comma-delimited list of values. The valid values vary depending on the operation. For the `package` operation the valid values are `all`, `usr`, and `minify`. For the `dump` operation the valid values are `heap`, `system`, and `thread`. For the `javadump` operation the valid values are `heap` and `system`. | Yes, only when the `os` option is set |
+| os| A comma-delimited list of operating systems that you want the packaged server to support. Only used with the `package` operation. The 'include' option must be set to 'minify'. | No |
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -61,6 +61,7 @@
         <wlp:server ref="testServer" operation="stop" />
         <wlp:uninstall-feature ref="testServer" name="mongodb-2.0"/>
         <wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.zip" />
+    	<wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.os.zip" include="minify" os="OS/400,-z/OS"/>
     </target>
 
 </project>

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -56,6 +56,9 @@ public class ServerTask extends AbstractTask {
     // used with 'create' operation
     private String template;
     
+    // used with 'package' operation
+    private String os;
+    
     @Override
     protected void initTask() {
         super.initTask();
@@ -233,6 +236,7 @@ public class ServerTask extends AbstractTask {
         List<String> command = getInitialCommand(operation);
         addArchiveOption(command);
         addIncludeOption(command);
+        addOsOption(command);
         processBuilder.command(command);
         Process p = processBuilder.start();
         checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());
@@ -278,6 +282,12 @@ public class ServerTask extends AbstractTask {
     private void addIncludeOption(List<String> command) {
         if (include != null) {
             command.add("--include=" + include);
+        }
+    }
+    
+    private void addOsOption(List<String> command) {
+        if (os != null) {
+            command.add("--os=" + os);
         }
     }
     
@@ -344,6 +354,20 @@ public class ServerTask extends AbstractTask {
      */
     public void setTimeout(String timeout) {
         this.timeout = timeout;
+    }
+
+    /**
+     * @return the os
+     */
+    public String getOs() {
+        return os;
+    }
+
+    /**
+     * @param os the os to set
+     */
+    public void setOs(String os) {
+        this.os = os;
     }
     
     public String getResultProperty() {


### PR DESCRIPTION
Changes to README.md:
<ul>
<li>Changed the 'Required' field of <i>include</i> parameter to <b>Yes, only when the `os` option is set</b>.</li>
<li>Added the <i>os</i> attribute to the server task parameters table.</li>
</ul>
Changes to src/it/basic/build.xml:
<ul>
<li>Added a package-os task.</li>
</ul>
Changes to src/main/java/net/wasdev/wlp/ant/ServerTask.java:
<ul>
<li>Added the <i>os</i> attribute along with its getter and setter.</li>
<li>Added the addOsOption method and its use in the doPackage method.</li>
</ul>
