### PR TITLE
Improve install-feature to include installUtility capabilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,12 +238,37 @@ The `install-feature` task installs a feature packaged as a Subsystem Archive (E
 | acceptLicense | Accept feature license terms and conditions. The default value is `false`. | No |
 | whenFileExits | Specifies the action to take if a file to be installed already exits. Use `fail` to abort the installation, `ignore` to continue the installation and ignore the file that exists, and `replace` to overwrite the existing file. | No | 
 | to | Specifies feature installation location. Set to `usr` to install as a user feature. Otherwise, set it to any configured product extension location. The default value is `usr`. | No |
-| name | Specifies the name of the Subsystem Archive (ESA file) to be installed. The name can be a feature name, a file name or a URL. | Yes | 
+| name | Specifies the name of the Subsystem Archive (ESA file) to be installed. The name can be a feature name, a file name or a URL. | Yes, only if there are no nested `feature` elements and the `installFromServer` parameter is set to false | 
+| from | Specify the local source directory from which features can be installed. If there are missing dependencies, they will be installed from the Liberty Repository. | No |
+| installFromServer | If it's set to true, all the not-installed features from the server.xml file will be installed along with their dependencies. The default value is `false`. | Yes, only if there are no nested `feature` elements nor `name` parameter |
+
+#### Nested Elements
+
+| Element | Description | Required |
+| --------- | ------------ | ----------|
+| feature | Specifies the name of the Subsystem Archive (ESA file) to be installed. The name can be a feature name, a file name or a URL. | Yes, only if the `name` parameter is not set and the `installFromServer` parameter is set to false |
 
 #### Examples
-```ant
-<wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true"/>
-```
+
+1. Install a single feature using the `name` parameter.
+
+ ```ant
+ <wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true"/>
+ ```
+
+2. Install one or more features using nested `feature` elements.
+ ```ant
+ <wlp:install-feature installDir="${wlp_install_dir}" whenFileExists="ignore" acceptLicense="true">
+         <feature>mongodb-2.0</feature>
+         <feature>oauth-2.0</feature>
+ </wlp:install-feature>
+ ```
+
+3. Install all the not-installed features from the server. The `serverName` parameter must be set.
+ ```ant
+ <wlp:install-feature installDir="${wlp_install_dir}" whenFileExists="ignore" acceptLicense="true"
+      serverName="${serverName}" installFromServer="true" />
+ ```
 
 ### uninstall-feature task
 ---
@@ -259,9 +284,25 @@ The `uninstall-feature` task uninstalls a feature from the Liberty runtime.
 | userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
 | outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
 | ref | Reference to an existing server task definition to reuse its server configuration. Configuration such as `installDir`, `userDir`, `outputDir`, and `serverName` are reused from the referenced server task. | No |
-| name | Specifies the feature name to be uninstalled. The name can a short name or a symbolic name of a Subsystem Archive (ESA file). | Yes | 
+| name | Specifies the feature name to be uninstalled. The name can a short name or a symbolic name of a Subsystem Archive (ESA file). | Yes, only if there are no nested `feature` elements | 
+
+#### Nested Elements
+
+| Element | Description | Required |
+| --------- | ------------ | ----------|
+| feature | Specifies the feature name to be uninstalled. The name can a short name or a symbolic name of a Subsystem Archive (ESA file). | Yes, only if the name parameter is not set |
 
 #### Examples
-```ant
-<wlp:uninstall-feature installDir="${wlp_install_dir}" name="mongodb-2.0"/>
-```
+
+1. Uninstall a single feature using the `name` parameter.
+ ```ant
+ <wlp:uninstall-feature installDir="${wlp_install_dir}" name="mongodb-2.0"/>
+ ```
+
+2. Uninstall one or more features using nested `feature` elements.
+ ```ant
+ <wlp:uninstall-feature installDir="${wlp_install_dir}">
+         <feature>mongodb-2.0</feature>
+         <feature>oauth-2.0</feature>
+ </wlp:uninstall-feature>
+ ```

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -33,10 +33,16 @@
 
         <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
         <!-- install the same feature twice - should not cause an error -->
-        <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
+    	<wlp:install-feature ref="testServer" whenFileExists="ignore" acceptLicense="true">
+			<feature>mongodb-2.0</feature>
+			<feature>oauth-2.0</feature>
+		</wlp:install-feature>
 
         <copy overwrite="true" file="${serverConfig}" toFile="${wlp.usr.dir}/servers/${servername}/server.xml" />
         <copy file="${bootProp}" toFile="${wlp.usr.dir}/servers/${servername}/bootstrap.properties" />
+    	
+    	<!-- should install openid-2.0 -->
+    	<wlp:install-feature ref="testServer" whenFileExists="ignore" acceptLicense="true" installFromServer="true" />
     </target>
 
     <target name="deploy" depends="createServer">
@@ -59,7 +65,11 @@
         <wlp:undeploy ref="testServer" file="test-eba.eba" timeout="60000" />
 
         <wlp:server ref="testServer" operation="stop" />
-        <wlp:uninstall-feature ref="testServer" name="mongodb-2.0"/>
+        <wlp:uninstall-feature ref="testServer" >
+            <feature>mongodb-2.0</feature>
+            <feature>oauth-2.0</feature>
+            <feature>openid-2.0</feature>
+        </wlp:uninstall-feature>
         <wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.zip" />
     	<wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.os.zip" include="minify" os="OS/400,-z/OS"/>
     </target>

--- a/src/it/basic/src/test/resources/server.xml
+++ b/src/it/basic/src/test/resources/server.xml
@@ -2,5 +2,6 @@
      <featureManager>        
         <feature>wab-1.0</feature>
         <feature>jsp-2.2</feature>
+        <feature>openid-2.0</feature>
     </featureManager>     
 </server>

--- a/src/main/java/net/wasdev/wlp/ant/FeatureManagerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/FeatureManagerTask.java
@@ -16,6 +16,8 @@
 package net.wasdev.wlp.ant;
 
 import java.util.Properties;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Install feature task.
@@ -26,6 +28,13 @@ public abstract class FeatureManagerTask extends AbstractTask {
 
     // name of the feature to install or URL
     protected String name;
+    
+    // list of features to be installed/uninstalled.
+    protected List<Feature> features = new ArrayList<Feature>();
+    
+    public void addFeature(Feature feature) {
+        features.add(feature);
+    }
 
     @Override
     protected void initTask() {
@@ -86,4 +95,19 @@ public abstract class FeatureManagerTask extends AbstractTask {
             return val;
         }
     }
+    
+    /* Class for the nested 'feature' element. */
+    public static class Feature {
+        private String feature;
+        
+        public String getFeature() {
+            return feature;
+        }
+        
+        public void addText(String txt) {
+            feature = txt;
+        }
+        
+    }
+    
 }

--- a/src/main/java/net/wasdev/wlp/ant/InstallFeatureTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/InstallFeatureTask.java
@@ -15,11 +15,18 @@
  */
 package net.wasdev.wlp.ant;
 
+import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.apache.tools.ant.BuildException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * Install feature task.
@@ -34,11 +41,18 @@ public class InstallFeatureTask extends FeatureManagerTask {
 
     // action to take if a file to be installed already exists (fail|ignore|replace)
     private String whenFileExists;
+    
+    // local source directory from which features can be installed
+    private String from;
+
+    // install features from server.xml
+    private boolean installFromServer = false;
 
     @Override
     public void execute() {
-        if (name == null || name.length() <= 0) {
-            throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "name"));
+        if ((name == null || name.length() <= 0) && features.isEmpty() && !installFromServer) {
+            throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"),
+                    "'nested features', 'install from server' or the 'name'"));
         }
 
         initTask();
@@ -53,6 +67,81 @@ public class InstallFeatureTask extends FeatureManagerTask {
     }
 
     private void doInstall() throws Exception {
+        List<String> command;
+        if (!(name == null || name.length() <= 0)) {
+            command = initCommand();
+            command.add(name);
+            processCommand(command);
+        } 
+        if (!features.isEmpty()) {
+            for (Feature feature : features) {
+                command = initCommand();
+                command.add(feature.getFeature());
+                processCommand(command);
+            }
+        }
+        if (installFromServer) {
+            if (serverName == null || serverName.isEmpty()) {
+                throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "serverName"));
+            }
+            String serverXml;
+            if (isWindows) {
+                serverXml = userDir + "\\servers\\" + serverName + "\\server.xml";
+            } else {
+                serverXml = userDir + "/servers/" + serverName + "/server.xml";
+            }
+            List<String> featuresInstalled = getFeaturesInstalled();
+            List<String> serverFeatures = getFeatures(serverXml, true);
+            serverFeatures.removeAll(featuresInstalled);
+
+            for (String feature : serverFeatures) {
+                command = initCommand();
+                command.add(feature);
+                processCommand(command);
+            }
+        }
+    }
+    
+    private List<String> getFeaturesInstalled() throws Exception {
+        List<String> features = new ArrayList<String>();
+        List<String> command = new ArrayList<String>();
+        command.add(cmd);
+        command.add("featureList");
+        command.add("featureList.xml");
+        processCommand(command);
+        String xml;
+        if (isWindows) {
+            xml = installDir + "\\featureList.xml";
+        } else {
+            xml = installDir + "/featureList.xml";
+        }
+        features = getFeatures(xml, false);
+        File xmlFile = new File(xml);
+        xmlFile.delete();
+        return features;
+    }
+
+    private List<String> getFeatures(String xml, boolean isServerXml) throws Exception {
+        List<String> features = new ArrayList<String>();
+        File fileXml = new File(xml);
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document docXml = builder.parse(fileXml);
+        NodeList nodeFeatures = docXml.getElementsByTagName("feature");
+
+        for (int i = 0; i < nodeFeatures.getLength(); i++) {
+            Element feature = (Element) nodeFeatures.item(i);
+            if (isServerXml) {
+                features.add(feature.getTextContent());
+            } else {
+                features.add(feature.getAttribute("name"));
+            }
+        }
+
+        return features;
+    }
+    
+    private List<String> initCommand(){
         List<String> command = new ArrayList<String>();
         command.add(cmd);
         command.add("install");
@@ -64,10 +153,17 @@ public class InstallFeatureTask extends FeatureManagerTask {
         if (to != null) {
             command.add("--to=" + to);
         }
+        if (from != null) {
+            command.add("--location=" + from);
+        }
         if (whenFileExists != null) {
             command.add("--when-file-exists=" + whenFileExists);
         }
-        command.add(name);
+        
+        return command;
+    }
+    
+    private void processCommand(List<String> command) throws Exception {
         processBuilder.command(command);
         Process p = processBuilder.start();
         checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue(), ReturnCode.ALREADY_EXISTS.getValue());
@@ -104,6 +200,22 @@ public class InstallFeatureTask extends FeatureManagerTask {
 
     public void setWhenFileExists(String whenFileExists) {
         this.whenFileExists = whenFileExists;
+    }
+    
+    public void setInstallFromServer(boolean installFromServer) {
+        this.installFromServer = installFromServer;
+    }
+
+    public boolean isInstallFromServer() {
+        return installFromServer;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
     }
 
 }

--- a/src/main/java/net/wasdev/wlp/ant/UninstallFeatureTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/UninstallFeatureTask.java
@@ -27,11 +27,7 @@ import org.apache.tools.ant.BuildException;
 public class UninstallFeatureTask extends FeatureManagerTask {
 
     @Override
-    public void execute() {
-        if (name == null || name.length() <= 0) {
-            throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "name"));
-        }
-        
+    public void execute() {        
         initTask();
         
         try {
@@ -44,14 +40,31 @@ public class UninstallFeatureTask extends FeatureManagerTask {
     }
 
     private void doUninstall() throws Exception {
-        List<String> command = new ArrayList<String>();
-        command.add(cmd);
-        command.add("uninstall");      
-        command.add("--noPrompts");
-        command.add(name);
-        processBuilder.command(command);
-        Process p = processBuilder.start();
-        checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());
+        List<String> command;
+        if (features.isEmpty()) {
+            if (name == null || name.length() <= 0) {
+                throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "features elements or a name"));
+            }
+            command = new ArrayList<String>();
+            command.add(cmd);
+            command.add("uninstall");      
+            command.add("--noPrompts");
+            command.add(name);
+            processBuilder.command(command);
+            Process p = processBuilder.start();
+            checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());
+        } else {
+            for (Feature feature : features) {
+                command = new ArrayList<String>();
+                command.add(cmd);
+                command.add("uninstall");      
+                command.add("--noPrompts");
+                command.add(feature.getFeature());
+                processBuilder.command(command);
+                Process p = processBuilder.start();
+                checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Issues fixed: https://github.com/WASdev/ci.ant/issues/44 https://github.com/WASdev/ci.ant/issues/38

Changes to README:
<ul>
<li>Changed the <i>required</i> field of the <i>name</i> parameter to <b>Yes, only if there are no nested `feature` elements</b>, of both 'install-feature' and 'uninstall-feature' tasks.</li>
<li>Added the description of the nested element 'feature'.</li>
<li>Added the parameter <i>installFromServer.</i>
<li>Added some examples.</li>
</ul>
Changes to IT build.xml:
<ul>
<li>Integration tests for install and uninstall features using the nested <i>feature</i> element.</li>
<li>Install a feature (openid-2.0) reading the server.xml file.</li>
</ul>
Changes to server.xml:
<ul>
<li>Added the feature openid-2.0.</li>
</ul>
Changes to FeatureManagerTask.java:
<ul>
<li>Added a class container, a list and the method <i>addFeature()</i> for the nested <i>feature</i> element.</li>
</ul>
Changes to InstallFeatureTask.java and UninstallFeatureTask.java:
<ul>
<li>Changed the conditions: The user can use either the <i>name</i> parameter, the nested <i>feature</i> element(s) or <i>installFromServer</i> to add feature(s).</li>
</ul>