### PR TITLE
Enhance install-feature task to include installUtility capabilities & install features as nested elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,15 +235,32 @@ The `install-feature` task installs a feature packaged as a Subsystem Archive (E
 | userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
 | outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
 | ref | Reference to an existing server task definition to reuse its server configuration. Configuration such as `installDir`, `userDir`, `outputDir`, and `serverName` are reused from the referenced server task. | No |
-| acceptLicense | Accept feature license terms and conditions. The default value is `false`. | No |
-| whenFileExits | Specifies the action to take if a file to be installed already exits. Use `fail` to abort the installation, `ignore` to continue the installation and ignore the file that exists, and `replace` to overwrite the existing file. | No | 
+| acceptLicense | Accept feature license terms and conditions. The default value is `false`. | No | 
 | to | Specifies feature installation location. Set to `usr` to install as a user feature. Otherwise, set it to any configured product extension location. The default value is `usr`. | No |
-| name | Specifies the name of the Subsystem Archive (ESA file) to be installed. The name can be a feature name, a file name or a URL. | Yes | 
+| from | Specifies a single directory-based repository as the source of the assets. | No |
+| name | Specifies the name of the Subsystem Archive (ESA file) to be installed. The name can be a feature name, a file name or a URL. | No | 
+
+To install the features from the `server.xml` file, don't specify any features in the name or in [nested features](#nested-feature-elements).
 
 #### Examples
-```ant
-<wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true"/>
-```
+1. Install a single feature using the `name` parameter.
+ ```ant
+ <wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true"/>
+ ```
+ 
+2. Install one or more features using nested `feature` elements.
+ ```ant
+ <wlp:install-feature installDir="${wlp_install_dir}" whenFileExists="ignore" acceptLicense="true">
+         <feature>mongodb-2.0</feature>
+         <feature>oauth-2.0</feature>
+ </wlp:install-feature>
+ ```
+
+3. Install all the not-installed features from the server.
+ ```ant
+ <wlp:install-feature installDir="${wlp_install_dir}" whenFileExists="ignore" acceptLicense="true"
+      serverName="${serverName}" />
+ ```
 
 ### uninstall-feature task
 ---
@@ -259,12 +276,28 @@ The `uninstall-feature` task uninstalls a feature from the Liberty runtime.
 | userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
 | outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No | 
 | ref | Reference to an existing server task definition to reuse its server configuration. Configuration such as `installDir`, `userDir`, `outputDir`, and `serverName` are reused from the referenced server task. | No |
-| name | Specifies the feature name to be uninstalled. The name can a short name or a symbolic name of a Subsystem Archive (ESA file). | Yes | 
+| name | Specifies the feature name to be uninstalled. The name can a short name or a symbolic name of a Subsystem Archive (ESA file). | Yes, only if there are no [nested features](#nested-feature-elements) | 
 
 #### Examples
-```ant
-<wlp:uninstall-feature installDir="${wlp_install_dir}" name="mongodb-2.0"/>
-```
+
+1. Uninstall a single feature using the `name` parameter.
+ ```ant
+ <wlp:uninstall-feature installDir="${wlp_install_dir}" name="mongodb-2.0"/>
+ ```
+ 
+2. Uninstall one or more features using nested `feature` elements.
+ ```ant
+ <wlp:uninstall-feature installDir="${wlp_install_dir}">
+         <feature>mongodb-2.0</feature>
+         <feature>oauth-2.0</feature>
+ </wlp:uninstall-feature>
+ ```
+ 
+#### Nested Feature Elements
+
+| Element | Description | Required |
+| --------- | ------------ | ----------|
+| feature | Specifies the feature name to be uninstalled. The name can a short name or a symbolic name of a Subsystem Archive (ESA file). | No |
 
 ### clean task
 ---

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -34,9 +34,19 @@
         <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
         <!-- install the same feature twice - should not cause an error -->
         <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
+        
+        <!-- install features in nested elements -->
+        <wlp:install-feature ref="testServer" acceptLicense="true">
+            <!-- install the same feature again - should not cause an error -->
+            <feature>mongodb-2.0</feature>
+            <feature>oauth-2.0</feature>
+        </wlp:install-feature>
 
         <copy overwrite="true" file="${serverConfig}" toFile="${wlp.usr.dir}/servers/${servername}/server.xml" />
         <copy file="${bootProp}" toFile="${wlp.usr.dir}/servers/${servername}/bootstrap.properties" />
+        
+        <!-- install the features from the server.xml file that are not installed (openid-2-0) -->
+        <wlp:install-feature ref="testServer" acceptLicense="true" />
     </target>
 
     <target name="deploy" depends="createServer">
@@ -60,6 +70,13 @@
 
         <wlp:server ref="testServer" operation="stop" />
         <wlp:uninstall-feature ref="testServer" name="mongodb-2.0"/>
+        
+        <!-- uninstall features using nested elements -->
+        <wlp:uninstall-feature ref="testServer">
+            <feature>oauth-2.0</feature>
+            <feature>openid-2.0</feature>
+        </wlp:uninstall-feature>
+        
         <wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.zip" />
     	<wlp:server ref="testServer" operation="package" archive="${target.dir}/wlp.ant.test.os.zip" include="minify" os="OS/400,-z/OS"/>
         <wlp:clean ref="testServer" apps="true" dropins="true" />

--- a/src/it/basic/src/test/resources/server.xml
+++ b/src/it/basic/src/test/resources/server.xml
@@ -2,5 +2,6 @@
      <featureManager>        
         <feature>wab-1.0</feature>
         <feature>jsp-2.2</feature>
+        <feature>openid-2.0</feature>
     </featureManager>     
 </server>

--- a/src/main/java/net/wasdev/wlp/ant/FeatureManagerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/FeatureManagerTask.java
@@ -16,6 +16,8 @@
 package net.wasdev.wlp.ant;
 
 import java.util.Properties;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Install feature task.
@@ -26,16 +28,26 @@ public abstract class FeatureManagerTask extends AbstractTask {
 
     // name of the feature to install or URL
     protected String name;
+    
+    // list of features to be installed/uninstalled.
+    protected List<Feature> features = new ArrayList<Feature>();
+    
+    /** Add a Feature object
+     * @param feature The Feature object.
+     */
+    public void addFeature(Feature feature) {
+        features.add(feature);
+    }
 
     @Override
     protected void initTask() {
         super.initTask();
 
         if (isWindows) {
-            cmd = installDir + "\\bin\\featureManager.bat";
+            cmd = installDir + "\\bin\\installUtility.bat";
             processBuilder.environment().put("EXIT_ALL", "1");
         } else {
-            cmd = installDir + "/bin/featureManager";
+            cmd = installDir + "/bin/installUtility";
         }
 
         Properties sysp = System.getProperties();
@@ -59,6 +71,20 @@ public abstract class FeatureManagerTask extends AbstractTask {
      */
     public void setName(String name) {
         this.name = name;
+    }
+    
+    /**
+     * @return the features
+     */
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
+    /**
+     * @param features the features to set
+     */
+    public void setFeatures(List<Feature> features) {
+        this.features = features;
     }
 
     /** featureManager's exit codes. */
@@ -85,5 +111,22 @@ public abstract class FeatureManagerTask extends AbstractTask {
         public int getValue() {
             return val;
         }
+    }
+    
+    /** Class for the nested 'feature' element. */
+    public static class Feature {
+        private String feature;
+        
+        /**
+         * @return the name of the feature.
+         */
+        public String getFeature() {
+            return feature;
+        }
+        
+        public void addText(String txt) {
+            feature = txt;
+        }
+        
     }
 }

--- a/src/main/java/net/wasdev/wlp/ant/InstallFeatureTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/InstallFeatureTask.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014.
+ * (C) Copyright IBM Corporation 2014, 2015.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package net.wasdev.wlp.ant;
 
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,12 +33,12 @@ public class InstallFeatureTask extends FeatureManagerTask {
 
     // action to take if a file to be installed already exists (fail|ignore|replace)
     private String whenFileExists;
+    
+    // a single directory-based repository as the source of the assets for the installUtility command
+    private String from;
 
     @Override
     public void execute() {
-        if (name == null || name.length() <= 0) {
-            throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "name"));
-        }
 
         initTask();
 
@@ -53,6 +52,26 @@ public class InstallFeatureTask extends FeatureManagerTask {
     }
 
     private void doInstall() throws Exception {
+        List<String> command;
+        command = initCommand();
+        if (name != null && !name.isEmpty()) {
+            command.add(name);
+        } 
+        if (!features.isEmpty()) {
+            for (Feature feature : features) {
+                command.add(feature.getFeature());
+            }
+        }
+        if (features.isEmpty() && (name == null || name.isEmpty())) {
+            command.add(serverName);
+        }
+        processCommand(command);
+    }
+    
+    /** Generate a String list containing all the parameter for the command.
+     * @returns A List<String> containing the command to be executed.
+     */
+    private List<String> initCommand(){
         List<String> command = new ArrayList<String>();
         command.add(cmd);
         command.add("install");
@@ -64,10 +83,17 @@ public class InstallFeatureTask extends FeatureManagerTask {
         if (to != null) {
             command.add("--to=" + to);
         }
-        if (whenFileExists != null) {
-            command.add("--when-file-exists=" + whenFileExists);
+        if (from != null) {
+            command.add("--from=" + from);
         }
-        command.add(name);
+        
+        return command;
+    }
+    
+    /** Process the command.
+     * @param command A String list containing the command to be executed.
+     */
+    private void processCommand(List<String> command) throws Exception {
         processBuilder.command(command);
         Process p = processBuilder.start();
         checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue(), ReturnCode.ALREADY_EXISTS.getValue());
@@ -97,13 +123,29 @@ public class InstallFeatureTask extends FeatureManagerTask {
     public void setTo(String to) {
         this.to = to;
     }
-
+    
+    /**
+     * @deprecated installUtility does not have a whenFileExist parameter.
+     */
+    @Deprecated
     public String getWhenFileExists() {
         return whenFileExists;
     }
 
+    /**
+     * @deprecated installUtility does not have a whenFileExist parameter.
+     */
+    @Deprecated
     public void setWhenFileExists(String whenFileExists) {
         this.whenFileExists = whenFileExists;
+    }
+    
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
     }
 
 }

--- a/src/main/java/net/wasdev/wlp/ant/UninstallFeatureTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/UninstallFeatureTask.java
@@ -28,8 +28,8 @@ public class UninstallFeatureTask extends FeatureManagerTask {
 
     @Override
     public void execute() {
-        if (name == null || name.length() <= 0) {
-            throw new BuildException(MessageFormat.format(messages.getString("error.server.operation.validate"), "name"));
+        if ((name == null || name.isEmpty()) && features.isEmpty()) {
+            throw new BuildException(MessageFormat.format(messages.getString("error.parameter.empty"), "name"));
         }
         
         initTask();
@@ -48,7 +48,16 @@ public class UninstallFeatureTask extends FeatureManagerTask {
         command.add(cmd);
         command.add("uninstall");      
         command.add("--noPrompts");
-        command.add(name);
+        
+        if (name != null && !name.isEmpty()) {
+            command.add(name);
+        }
+        if (!features.isEmpty()) {
+            for (Feature feature : features) {
+                command.add(feature.getFeature());
+            }
+        }
+        
         processBuilder.command(command);
         Process p = processBuilder.start();
         checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());

--- a/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
+++ b/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
@@ -102,9 +102,9 @@ error.deploy.file.isdirectory=CWWKM2026E: The file parameter is a directory, the
 error.deploy.file.isdirectory.explanation=The deploy task cannot deploy the application as the file parameter is a directory.
 error.deploy.file.isdirectory.useraction=Correct the value of the file parameter.
 
-error.parameter.invalid=CWWKM2027E: The {0} parameter is empty.
-error.parameter.invalid.explanation=The {0} parameter is empty.
-error.parameter.invalid.useraction=Correct the value of the file parameter.
+error.parameter.empty=CWWKM2027E: The {0} parameter is empty.
+error.parameter.empty.explanation=The {0} parameter is empty.
+error.parameter.empty.useraction=Correct the value of the file parameter.
 
 error.parameter.type.invalid=CWWKM2028E: The {0} parameter is not supported.
 error.parameter.type.invalid.explanation=The {0} parameter is not supported.


### PR DESCRIPTION
Issues fixed: https://github.com/WASdev/ci.ant/issues/38 https://github.com/WASdev/ci.ant/issues/44

install-feature task now uses the _installUtility_ batch instead of _featureMager_ and can now install all features from the server.xml file that aren't already installed (<i>installFromServerXml</i> parameter). Also, the user can specify a single directory-based repository as the source of the assets, and, finally, the <b>install-feature</b> and <b>uninstall-feature</b> tasks can now accept nested <i>feature</i> elements.

Changes to README:
<ul>
<li><i>whenFileExist</i> parameter removed.</li>
<li><i>installFromServerXml</i>and <i>from</i> parameters added to install-feature task.</li>
<li>Nested <i>feature</i> element added to install-feature and uninstall-feature tasks.</li>
<li>Some examples added.</li>
</ul>

Changes to build.xml:
<ul>
<li>Install features using nested <i>feature</i> elements.</li>
<li>Removed the whenFileExist parameter.</li>
</ul>

Changes to server.xml:
<ul>
<li>Added the feature <i>openid-2.0</i> feature.</li>
</ul>

Changes to FeatureManagerTask.java:
<ul>
<li>Added a class container for the nested <i>feature</i> element.</li>
</ul>

Changes to InstallFeatureTask.java:
<ul>
<li>Added the <i>installFromServerXml</i> and <i>from</i> attributes.</li>
<li>Added the methods initCommand and processCommand.</li>
<li>doInstall enhanced to apply the install from server.xml file and from the nested feature elements.</li>
</ul>

Changes to UninstallFeatureTask.java:
<ul>
<li>doUninstall enhanced to apply the uninstall from the nested feature elements.</li>
</ul>