### PR TITLE
Improve deploy task to deploy apps to configDropins/overrides as server.xml entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,12 @@ To install the features from the `server.xml` file, don't specify any features i
 #### Examples
 1. Install a single feature using the `name` parameter.
  ```ant
- <wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true"/>
+ <wlp:install-feature installDir="${wlp_install_dir}" name="mongodb-2.0" acceptLicense="true"/>
  ```
  
 2. Install one or more features using nested `feature` elements.
  ```ant
- <wlp:install-feature installDir="${wlp_install_dir}" whenFileExists="ignore" acceptLicense="true">
+ <wlp:install-feature installDir="${wlp_install_dir}" acceptLicense="true">
          <feature>mongodb-2.0</feature>
          <feature>oauth-2.0</feature>
  </wlp:install-feature>
@@ -258,7 +258,7 @@ To install the features from the `server.xml` file, don't specify any features i
 
 3. Install all the not-installed features from the server.
  ```ant
- <wlp:install-feature installDir="${wlp_install_dir}" whenFileExists="ignore" acceptLicense="true"
+ <wlp:install-feature installDir="${wlp_install_dir}" acceptLicense="true"
       serverName="${serverName}" />
  ```
 

--- a/README.md
+++ b/README.md
@@ -157,10 +157,11 @@ The `deploy` task supports deployment of one or more applications to the Liberty
 | file | Location of a single application to be deployed. See [file attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). The application type can be war, ear, rar, eba, zip , or jar. | Yes, only when the `fileset` attribute is not specified. |
 | fileset | Location of multiple applications to be deployed. See [fileset attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). | Yes, only when the `file` attribute is not specified.|
 | timeout| Waiting time before the deployment completes successfully. The default value is 30 seconds. The unit is milliseconds. | No | 
+| deployTo| Specify the deploy destination. The possible values are `dropins` and `configDropins`. When deploying to `dropins`, the file will be copied to `${wlp_user_dir}/dropins`, but when deploying to `configDropins`, a new xml file _appName.extension.xml_ will be created in `${wlp_user_dir}/configDropins/overrides` (The directory will be created if it does not exist) containing the server _application_ entry with the file location and name. The default value is `dropins`. | No |
 
 #### Examples
 
-1. Using `fileset`.
+1. Deploy applications to the dropins folder using `fileset`.
 
  ```ant
  <wlp:deploy ref="wlp.ant.test">
@@ -170,11 +171,27 @@ The `deploy` task supports deployment of one or more applications to the Liberty
  </wlp:deploy>
  ```
 
-2. Using `file`.
+2. Deploy of a single application to the dropins folder using `file`.
 
  ```ant
 <wlp:deploy ref="wlp.ant.test" file="${basedir}/resources/SimpleOSGiApp.eba" timeout="40000"/>
-```
+ ```
+
+3. Deploy applications to the configDropins/overrides folder as _appName.extension.xml_ using `fileset`.
+
+ ```ant
+ <wlp:deploy ref="wlp.ant.test" deployTo="configDropins">
+     <fileset dir="${basedir}/resources/">
+         <include name="**/*.war"/>
+     </fileset>
+ </wlp:deploy>
+ ```
+
+4. Deploy of a single application to the configDropins/overrides folder as _appName.extension.xml_ using `file`.
+
+ ```ant
+<wlp:deploy ref="wlp.ant.test" file="${basedir}/resources/SimpleOSGiApp.eba" timeout="40000" deployTo="configDropins" />
+ ```
 
 ### undeploy task
 ---
@@ -193,17 +210,18 @@ The `undeploy` task supports undeployment of a single application from the Liber
 | file | Name of the application to be undeployed. The application type can be war, ear, rar, eba, zip , or jar. | No |
 | patternset | Includes and excludes patterns of applications to be undeployed. See [patternset attribute in Apache Ant](http://ant.apache.org/manual/Types/patternset.html). | No |
 | timeout | Waiting time before the undeployment completes successfully. The default value is 30 seconds. The unit is milliseconds. | No | 
+| from | From where the application will be undeployed. The possible values are `dropins` and `configDropins`. The default value is `dropins`. | No |
 
 When `file` has been set the `patternset` parameter will be ignored, also when the `file` and `patternset` parameters are not set the task will undeploy all the deployed applications.
 #### Examples
 
-1. Undeploy the `SimpleOSGiApp.eba` application.
+1. Undeploy the `SimpleOSGiApp.eba` application from the dropins folder.
 
  ```ant
 <wlp:undeploy ref="wlp.ant.test" file="SimpleOSGiApp.eba" timeout="60000"/>
  ```
 
-2. Undeploy all the applications with the `.war` extension except the `example.war` file.
+2. Undeploy all the applications with the `.war` extension except the `example.war` file from the dropins folder.
 
  ```ant
  <patternset id="mypattern">
@@ -215,10 +233,34 @@ When `file` has been set the `patternset` parameter will be ignored, also when t
  </wlp:undeploy>
  ```
 
-3. Undeploy all the applications previously deployed on the server.
+3. Undeploy all the applications previously deployed on the dropins folder.
 
  ```ant
 <wlp:undeploy ref="wlp.ant.test" timeout="60000"/>
+ ```
+ 
+ 4. Undeploy the `SimpleOSGiApp.eba` application xml entry from the configDropins/overrides folder.
+
+ ```ant
+<wlp:undeploy ref="wlp.ant.test" file="SimpleOSGiApp.eba" timeout="60000" from="configDropins" />
+ ```
+
+5. Undeploy all the applications with the `.war.xml` extension except the `example.war.xml` file from the configDropins/overrides folder.
+
+ ```ant
+ <patternset id="mypattern">
+     <include name="**/*.war.xml"/>
+     <exclude name="example.war.xml"/>
+ </patternset>
+ <wlp:undeploy ref="wlp.ant.test"  timeout="20000" from="configDropins">
+     <patternset refid="mypattern"/>
+ </wlp:undeploy>
+ ```
+
+6. Undeploy all the applications previously deployed on the configDropins/overrides folder.
+
+ ```ant
+<wlp:undeploy ref="wlp.ant.test" timeout="60000" from="configDropins"/>
  ```
 
 ### install-feature task

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -61,6 +61,27 @@
         </wlp:deploy>
         <wlp:deploy ref="testServer" file="${basedir}/../setup/test-eba/target/test-eba.eba" timeout="40000" />
     </target>
+    
+    <target name="deploy-xml">
+
+        <copy file="${basedir}/../setup/test-war/target/test-war.war" toFile="${basedir}/../setup/test-war/target/test-war-xml.war" />
+
+        <wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}"  operation="status" />
+
+        <wlp:deploy ref="testServer" deployTo="configDropins" >
+            <fileset dir="${basedir}/../setup/test-war/target">
+                <include name="*xml.war" />
+            </fileset>
+        </wlp:deploy>
+        
+    </target>
+    
+    <target name="undeploy-xml">
+        
+        <wlp:undeploy id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" 
+            file="test-war-xml.war" timeout="50000" from="configDropins" />
+        
+    </target>
 
     <target name="undeploy">
 

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -31,6 +31,7 @@
 
         <wlp:server operation="create" ref="testServer" />
 
+        <!-- whenFileExists does not work anymore, but leave it to confirm backward compatibility -->
         <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />
         <!-- install the same feature twice - should not cause an error -->
         <wlp:install-feature ref="testServer" name="mongodb-2.0" whenFileExists="ignore" acceptLicense="true" />

--- a/src/it/basic/pom.xml
+++ b/src/it/basic/pom.xml
@@ -107,6 +107,7 @@
                                             <property name="wlp.version" value="${wlpVersion}" />
                                         </ant>
                                         <ant dir="${basedir}" antfile="${basedir}\build.xml" target="deploy" />
+                                        <ant dir="${basedir}" antfile="${basedir}\build.xml" target="deploy-xml" />
                                     </target>
                                 </configuration>
                             </execution>
@@ -118,6 +119,7 @@
                                 </goals>
                                 <configuration>
                                     <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\build.xml" target="undeploy-xml" />
                                         <ant dir="${basedir}" antfile="${basedir}\build.xml" target="undeploy" />
                                     </target>
                                 </configuration>
@@ -148,6 +150,9 @@
                                             used if the server is installed by the installServer target.-->
                                             <property name="wlp.install.dir" value="${wlpInstallDir}" />
                                         </ant>
+                                        <ant dir="${basedir}" antfile="${basedir}\build.xml" target="deploy-xml" >
+                                            <property name="wlp.install.dir" value="${wlpInstallDir}" />
+                                        </ant>
                                     </target>
                                 </configuration>
                             </execution>
@@ -159,6 +164,9 @@
                                 </goals>
                                 <configuration>
                                     <target>
+                                        <ant dir="${basedir}"  antfile="${basedir}\build.xml" target="undeploy-xml" >
+                                            <property name="wlp.install.dir" value="${wlpInstallDir}" />
+                                        </ant>
                                         <ant dir="${basedir}"  antfile="${basedir}\build.xml" target="undeploy" >
                                             <property name="wlp.install.dir" value="${wlpInstallDir}" />
                                         </ant>

--- a/src/it/basic/src/test/java/net/wasdev/wlp/ant/test/AppsTest.java
+++ b/src/it/basic/src/test/java/net/wasdev/wlp/ant/test/AppsTest.java
@@ -17,6 +17,11 @@ public class AppsTest {
     public void testSimpleEBA() {
         runTest("test-wab/index.jsp");
     }
+    
+    @Test
+    public void testHelloWARXml() {
+        runTest("test-war-xml/index.jsp");
+    }
 
     private void runTest(String test) {
         String port = System.getProperty("HTTP_default", "9080");

--- a/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
+++ b/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
@@ -106,9 +106,9 @@ error.parameter.empty=CWWKM2027E: The {0} parameter is empty.
 error.parameter.empty.explanation=The {0} parameter is empty.
 error.parameter.empty.useraction=Correct the value of the file parameter.
 
-error.parameter.type.invalid=CWWKM2028E: The {0} parameter is not supported.
-error.parameter.type.invalid.explanation=The {0} parameter is not supported.
-error.parameter.type.invalid.useraction=Correct the value of the file parameter.
+error.parameter.type.invalid=CWWKM2028E: The {0} parameter value is not supported.
+error.parameter.type.invalid.explanation=The {0} parameter value is not supported.
+error.parameter.type.invalid.useraction=Correct the value of the parameter.
 
 info.element.cleaned=CWWKM2029I: All the {0} elements have been deleted.
 info.element.cleaned.explanation=All the {0} elements have been deleted.
@@ -121,3 +121,7 @@ info.directory.noexist.useraction=No action is required.
 error.cannot.delete.file=CWWKM2031E: Cannot delete file {0}.
 error.cannot.delete.file.explanation=Cannot delete file {0}.
 error.cannot.delete.file.useraction=Verify that the file is not in use.
+
+info.app.already.deployed=CWWKM2032I: The application {0} is already deployed.
+info.app.already.deployed.explanation=The application {0} is already deployed.
+info.app.already.deployed.useraction=No action is required.


### PR DESCRIPTION
Issue resolved: https://github.com/WASdev/ci.ant/issues/2

The deploy task can now specify whether deploy to the dropins folder or configDropins/overrides folder as an xml file named _appName.extension.xml_. This file will have an _application_ tag with the name and location of the file deployed. To undeploy applications, it just deletes this file.

Changes to UndeployTask:
* If it is undeploying an xml file, change the location to _configDropins/overrides_ and add the .xml extension.

Changes to DeployTask:
* Created a method for deploy to dropins (deployToDropins) and deploy to xml file (deployToXml)
* Created a method to check the deployment of apps.

Changes to README:
* Added the parameters _deployTo_ to deploy task and _from_ to undeploy task.
* Updated the description and examples of both deploy and undeploy tasks.