### PR TITLE
#53: Setup build matrix for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: java
-jdk:
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+    - jdk: oraclejdk7
+      env: WLP_VERSION=8.5.5_07
+    - jdk: oraclejdk8
+      env: WLP_VERSION=8.5.5_08
 script:
-  - travis_wait mvn verify -Ponline-its -Dinvoker.streamLogs=true -DwlpVersion=8.5.5_08 -DwlpLicense=L-MCAO-9SYMVC
+  - travis_wait mvn verify -Ponline-its -Dinvoker.streamLogs=true -DwlpVersion=$WLP_VERSION -DwlpLicense=L-MCAO-9SYMVC


### PR DESCRIPTION
Setup a build matrix that runs Java 7 with a previous version of Liberty and Java 8 with the latest version of Liberty.
