### PR TITLE
Added parameter to define final Name on deploy task

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,7 +14,8 @@ The `deploy` task supports deployment of one or more applications to the Liberty
 | ref | Reference to an existing server task definition to reuse its server configuration. Configuration such as `installDir`, `userDir`, `outputDir`, and `serverName` are reused from the referenced server task. | No | 
 | file | Location of a single application to be deployed. See [file attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). The application type can be war, ear, rar, eba, zip , or jar. | Yes, only when the `fileset` attribute is not specified. |
 | fileset | Location of multiple applications to be deployed. See [fileset attribute in Apache Ant](http://ant.apache.org/manual/Types/fileset.html). | Yes, only when the `file` attribute is not specified.|
-| timeout| Waiting time before the deployment completes successfully. The default value is 30 seconds. The unit is milliseconds. | No | 
+| timeout| Waiting time before the deployment completes successfully. The default value is 30 seconds. The unit is milliseconds. | No |
+| finalName| Final name of the application to be deployed, this will be shown in the dropins folder. It is available just for `file` option .| No. If it is not set, the final name will be the same as the file name. | 
 
 #### Examples
 
@@ -31,5 +32,5 @@ The `deploy` task supports deployment of one or more applications to the Liberty
 2. Using `file`.
 
  ```ant
-<wlp:deploy ref="wlp.ant.test" file="${basedir}/resources/SimpleOSGiApp.eba" timeout="40000"/>
+<wlp:deploy ref="wlp.ant.test" file="${basedir}/resources/SimpleOSGiApp.eba" timeout="40000" finalName="finalSimpleOSGiApp"/>
 ```

--- a/docs/undeploy.md
+++ b/docs/undeploy.md
@@ -19,10 +19,10 @@ The `undeploy` task supports undeployment of a single application from the Liber
 When `file` has been set the `patternset` parameter will be ignored, also when the `file` and `patternset` parameters are not set the task will undeploy all the deployed applications.
 #### Examples
 
-1. Undeploy the `SimpleOSGiApp.eba` application.
+1. Undeploy the `finalSimpleOSGiApp.eba` application.
 
  ```ant
-<wlp:undeploy ref="wlp.ant.test" file="SimpleOSGiApp.eba" timeout="60000"/>
+<wlp:undeploy ref="wlp.ant.test" file="finalSimpleOSGiApp.eba" timeout="60000"/>
  ```
 
 2. Undeploy all the applications with the `.war` extension except the `example.war` file.

--- a/src/it/basic/build.xml
+++ b/src/it/basic/build.xml
@@ -58,7 +58,7 @@
                 <include name="*.war" />
             </fileset>
         </wlp:deploy>
-        <wlp:deploy ref="testServer" file="${basedir}/../setup/test-eba/target/test-eba.eba" timeout="40000" />
+        <wlp:deploy ref="testServer" file="${basedir}/../setup/test-eba/target/test-eba.eba" timeout="40000" finalName="final-test-eba"/>
     </target>
 
     <target name="undeploy">
@@ -66,7 +66,7 @@
         <wlp:server id="testServer" installDir="${wlp.install.dir}" serverName="${servername}" userDir="${wlp.usr.dir}" outputDir="${wlp.output.dir}" operation="status" />
 
         <wlp:undeploy ref="testServer" file="test-war.war" timeout="50000" />
-        <wlp:undeploy ref="testServer" file="test-eba.eba" timeout="60000" />
+        <wlp:undeploy ref="testServer" file="final-test-eba.eba" timeout="60000" />
 
         <wlp:server ref="testServer" operation="stop" />
         <wlp:uninstall-feature ref="testServer" name="mongodb-2.0"/>

--- a/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
+++ b/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
@@ -98,8 +98,8 @@ error.deploy.fileset.invalid=CWWKM2025E: The file specified as parameter cannot 
 error.deploy.fileset.invalid.explanation=The file specified as parameter in the fileset could not be found.
 error.deploy.fileset.invalid.useraction=Verify if the file to be deployed exists on the directory specified as parameter.
 
-error.deploy.file.isdirectory=CWWKM2026E: The file parameter is a directory, the parameter must be a file.
-error.deploy.file.isdirectory.explanation=The deploy task cannot deploy the application as the file parameter is a directory.
+error.deploy.file.isdirectory=CWWKM2026E: The file parameter is a directory or it is empty.
+error.deploy.file.isdirectory.explanation=The deploy task cannot deploy the application as the file parameter is a directory or the parameter is empty.
 error.deploy.file.isdirectory.useraction=Correct the value of the file parameter.
 
 error.parameter.empty=CWWKM2027E: The {0} parameter is empty.
@@ -121,3 +121,11 @@ info.directory.noexist.useraction=No action is required.
 error.cannot.delete.file=CWWKM2031E: Cannot delete file {0}.
 error.cannot.delete.file.explanation=Cannot delete file {0}.
 error.cannot.delete.file.useraction=Verify that the file is not in use.
+
+error.deploy.final.name.invalid=CWWKM2032E: The file {0} cannot be deployed because the final name is invalid. 
+error.deploy.final.name.invalid.explanation=The deploy task cannot deploy the application as the final name is invalid. 
+error.deploy.final.name.invalid.useraction=Correct the value of the final name.
+
+error.file.set=CWWKM2033E: Must specify file parameter if the finalName is set on the deploy task.
+error.file.set.explanation= Must specify file parameter if the finalName is set on the deploy task.
+error.file.set.useraction= Specify file parameter on the deploy task.


### PR DESCRIPTION
Issue solved: #49 
It is possible to change the final name of the application to be deployed. It is going to be useful to the issue related with strip versions in ci.maven project.

Changes to DeployTask:
- Added parameter to define the final name.
- Moved file's validation to the setFile Method.

Changes to documentation:
- Added finalName parameter and updated examples on deploy.md file.

Changes to IT:
- Added finalName parameter on deploy task.
- Changed file parameter to undeploy application with its finalName. 