### PR TITLE
Missing run option in server task description, changed message to empty fileset

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -18,7 +18,7 @@ Parameters supported by this task in addition to the [common parameters](common-
 
 | Attribute | Description | Required |
 | --------- | ------------ | ----------| 
-| operation | Server operations available as options: `create`, `start`, `stop`, `status`, `package`, `dump`, and `javadump`. | Yes | 
+| operation | Server operations available as options: `create`, `start`, `stop`, `status`, `package`, `dump`, `run` and `javadump`. | Yes | 
 | clean | Clean all cached information on server start up. The default value is `false`. Only used with the `start` operation. | No | 
 | timeout | Waiting time before the server starts. The default value is 30 seconds. The unit is milliseconds. Only used with the `start` operation. | No | 
 | include | A comma-delimited list of values. The valid values vary depending on the operation. For the `package` operation the valid values are `all`, `usr`, and `minify`. For the `dump` operation the valid values are `heap`, `system`, and `thread`. For the `javadump` operation the valid values are `heap` and `system`. | Yes, only when the `os` option is set |

--- a/src/main/java/net/wasdev/wlp/ant/DeployTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/DeployTask.java
@@ -122,7 +122,7 @@ public class DeployTask extends AbstractTask {
 
             //Throw a BuildException if the directory specified as parameter is empty.
             if (names.length == 0) {
-                throw new BuildException(getMessage("error.deploy.fileset.invalid"), getLocation());
+                throw new BuildException(getMessage("error.deploy.fileset.empty"), getLocation());
             }
 
             for (String element : names) {

--- a/src/main/java/net/wasdev/wlp/ant/UndeployTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/UndeployTask.java
@@ -86,7 +86,7 @@ public class UndeployTask extends AbstractTask {
             final String[] names = ds.getIncludedFiles();
 
             if (names.length == 0) {
-                throw new BuildException(messages.getString("error.undeploy.fileset.invalid"));
+                throw new BuildException(messages.getString("error.undeploy.fileset.empty"));
             }
 
             for (String element : names) {

--- a/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
+++ b/src/main/resources/net/wasdev/wlp/ant/AntMessages.properties
@@ -26,7 +26,7 @@ error.deploy=CWWKM2007E: Liberty only supports deployment war, eba, zip, ear or 
 error.deploy.explanation=The Liberty server only supports deployment of war, eba, zip, ear and jar files.
 error.deploy.useraction=Correct the application file name.
 
-error.deploy.fail=CWWKM2008E: Failed to deploy application {0}. The Start application message was not found in console.log
+error.deploy.fail=CWWKM2008E: Failed to deploy application {0}. The start application message was not found in console.log
 error.deploy.fail.explanation=An attempt was made to start the application, but the Start application message is not found in console.log.
 error.deploy.fail.useraction=Check the server configuration files and investigate the cause of the failure to start the application.
 
@@ -86,17 +86,17 @@ error.undeploy.fail=CWWKM2022E: Failed to undeploy application {0}. The Stop app
 error.undeploy.fail.explanation=An attempt was made to undeploy the application, but the application stop message was not issued.
 error.undeploy.fail.useraction=Check the console and trace log files to investigate the cause of the failure to stop the application.
 
-error.undeploy.fileset.invalid=CWWKM2023E: The file specified as parameter cannot be undeployed because it could not be found or it does not exist.
-error.undeploy.fileset.invalid.explanation=The file specified as parameter in the fileset could not be found.
-error.undeploy.fileset.invalid.useraction=Verify if the file to be undeployed exists on the dropins directory.
+error.undeploy.fileset.empty=CWWKM2023E: The fileset specified to be undeployed is empty.
+error.undeploy.fileset.empty.explanation=The fileset specified to be undeployed is empty.
+error.undeploy.fileset.empty.useraction=Verify the fileset to be undeployed.
 
 error.deploy.file.noexist=CWWKM2024E: The file {0} cannot be deployed because it does not exist. 
 error.deploy.file.noexist.explanation=The deploy task cannot deploy the application as the application does not exist. 
 error.deploy.file.noexist.useraction=Correct the value of the file name.
 
-error.deploy.fileset.invalid=CWWKM2025E: The file specified as parameter cannot be deployed because it could not be found or it does not exist.
-error.deploy.fileset.invalid.explanation=The file specified as parameter in the fileset could not be found.
-error.deploy.fileset.invalid.useraction=Verify if the file to be deployed exists on the directory specified as parameter.
+error.deploy.fileset.empty=CWWKM2025E: The fileset specified to be deployed is empty.
+error.deploy.fileset.empty.explanation=The fileset specified to be deployed is empty.
+error.deploy.fileset.empty.useraction=Verify the fileset to be deployed.
 
 error.deploy.file.isdirectory=CWWKM2026E: The file parameter must specify a file. The specified location is a directory: {0}.
 error.deploy.file.isdirectory.explanation=The deploy task cannot deploy the application as the file parameter is a directory.


### PR DESCRIPTION
- Added missing 'run' option in server task description
- Changed the message shown when the fileset specified to deploy/undeploy is empty. The message doesn't match with the explanation that it should show. 