### PR TITLE
Add an ant task for pre-compiling JSPs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ matrix:
     - jdk: oraclejdk7
       env: WLP_VERSION=8.5.5_09 WLP_LICENSE=L-MCAO-9SYMVC
     - jdk: oraclejdk8
-      env: WLP_VERSION=16.0.0_2 WLP_LICENSE=L-SWIS-A99U5C
+      env: WLP_VERSION=16.0.0_03 WLP_LICENSE=L-SWIS-ABKSXS
 script:
   - travis_wait mvn verify -Ponline-its -Dinvoker.streamLogs=true -DwlpVersion=$WLP_VERSION -DwlpLicense=$WLP_LICENSE

--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ The `wlp-anttasks.jar` provides the following tasks.
 | [install-feature](docs/install-feature.md#install-feature-task) | The `install-feature` task installs a feature packaged as a Subsystem Archive (ESA file) to the Liberty runtime. |
 | [uninstall-feature](docs/uninstall-feature.md#uninstall-feature-task) | The `uninstall-feature` task uninstalls a feature from the Liberty runtime. |
 | [clean](docs/clean.md#clean-task) | The `clean` task deletes every file in the `${wlp_output_dir}/logs`, `${wlp_output_dir}/workarea`, `${wlp_user_dir}/dropins` or `${wlp_user_dir}/apps`. |
+| [compileJSPs](docs/compileJSPs#compileJSPs-task) | The `compileJSPs` task compiles JSPs so they wont be done on demand at runtime.

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ The `wlp-anttasks.jar` provides the following tasks.
 | [install-feature](docs/install-feature.md#install-feature-task) | The `install-feature` task installs a feature packaged as a Subsystem Archive (ESA file) to the Liberty runtime. |
 | [uninstall-feature](docs/uninstall-feature.md#uninstall-feature-task) | The `uninstall-feature` task uninstalls a feature from the Liberty runtime. |
 | [clean](docs/clean.md#clean-task) | The `clean` task deletes every file in the `${wlp_output_dir}/logs`, `${wlp_output_dir}/workarea`, `${wlp_user_dir}/dropins` or `${wlp_user_dir}/apps`. |
-| [compileJSPs](docs/compileJSPs#compileJSPs-task) | The `compileJSPs` task compiles JSPs so they wont be done on demand at runtime.
+| [compileJSPs](docs/compileJSPs.md#compileJSPs-task) | The `compileJSPs` task compiles JSPs so they wont be done on demand at runtime.

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -8,7 +8,14 @@ Parameters shared by all the tasks except install-liberty.
 | Attribute | Description | Required |
 | --------- | ------------ | ----------|
 | installDir | Location of the Liberty profile server installation. | Yes, only if the `ref` attribute is not set. |
-| serverName | Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
-| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No | 
-| outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No |
 | ref | Reference to an existing server task definition to reuse its server configuration. Configuration such as `installDir`, `userDir`, `outputDir`, and `serverName` are reused from the referenced server task. | No |
+
+Parameters shared by all the tasks except install-liberty and compileJSPs.
+
+#### Parameters
+| Attribute | Description | Required |
+| --------- | ------------ | ----------|
+| serverName | Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
+| userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No |
+| outputDir | Value of the `${wlp_output_dir}` variable. The default value is `${installDir}/usr/servers/${serverName}`. | No |
+

--- a/docs/compileJSPs.md
+++ b/docs/compileJSPs.md
@@ -1,0 +1,30 @@
+## compileJSPs task
+---
+
+The 'compileJSPs' task will compile jsps. It has two modes of operation, the first allows it to compile the JSPs in specified war file, and merge the compiled JSPs in. The second will compile JSPs from a source directory. To compile the JSPs it requires an install of Liberty, it creates and starts a server in order to trigger the JSP compilation.
+
+#### Paramters
+
+Parameters supported by this task in addition to the [common parameters](common-parameters.md#common-parameters).
+
+| Attribute | Description | Required |
+| --------- | ------------ | ----------|
+| war | The file path to a war file containing JSPs that should be compiled | Required unless srcdir is set
+| srcdir | The path to a directory containing JSPs to be compiled | Required unless war is set
+| destdir | The path where the compiled JSPs should end up | Required if srcdir is set
+| source | The version of Java the source files are in. Can be 1.5, 1.6, 6, 1.7, 7, 1.8, 8. If not set defaults to ant Java version | No
+| jspVersion | The version of JSP for the JSPs. The installed Liberty server needs to support the required version of JSPs. Can be 2.2, 2.3. Defaults to 2.3 | No
+| features | A comma separated list of Liberty features that are required to compile the JSPs | No
+| classpath | The classpath required to compile the JSPs | No
+| classpathref | A ref to a path for compiling the JSPs | No
+
+
+#### Examples
+
+Compile the JSPs in a source folder
+
+    <compileJSPs srcdir="src/main/webapp" destdir="target/classes" installDir="${wlp.install.dir}"/> 
+
+Compile the JSPs in a war
+
+    <compileJSPs war="target/my-web.war" installDir="${wlp.install.dir}"/>

--- a/src/it/tests/compile-jsp-it/build.xml
+++ b/src/it/tests/compile-jsp-it/build.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<project xmlns:wlp="antlib:net.wasdev.wlp.ant" name="net.wasdev.wlp.ant.it">
+
+    <path id="wlp-ant-tasks.classpath">
+        <fileset dir="${basedir}/../../../../target" includes="wlp-anttasks-*.jar" />
+    </path>
+    <typedef resource="net/wasdev/wlp/ant/antlib.xml" uri="antlib:net.wasdev.wlp.ant" classpathref="wlp-ant-tasks.classpath" />
+
+    <property name="target.dir" value="${basedir}/../install-server-it/target" />
+
+    <!-- Defining server configuration -->
+    <property name="wlp.install.dir" value="${target.dir}/wlp" />
+
+    <target name="compileJsp">
+        <wlp:compileJSPs installDir="${wlp.install.dir}" war="${basedir}/../../setup/test-war/target/test-war.war" jspVersion="2.2"/>
+    </target>
+	
+</project>

--- a/src/it/tests/compile-jsp-it/pom.xml
+++ b/src/it/tests/compile-jsp-it/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wasdev.wlp.ant.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>compile-jsp-it</artifactId>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>online-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>package</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\build.xml" target="compileJsp" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>offline-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>package</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant dir="${basedir}" antfile="${basedir}\build.xml" target="compileJsp" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/src/it/tests/pom.xml
+++ b/src/it/tests/pom.xml
@@ -93,6 +93,7 @@
        <module>deploy-eba-it</module>
        <module>install-features-it</module>
        <module>package-server-it</module>
+       <module>compile-jsp-it</module>
        <module>basic-it</module>
     </modules>
 

--- a/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
@@ -134,7 +134,7 @@ public class InstallLibertyTask extends AbstractTask {
             throw new BuildException("License code not found.");
         }
         if (!licenseCode.equals(actualLicenseCode)) {
-            throw new BuildException("License code does not match.");
+            throw new BuildException("License code does not match. Expected: " + licenseCode + ", Actual: " + actualLicenseCode);
         }
     }
 

--- a/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
+++ b/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
@@ -51,7 +51,7 @@ public class CompileJSPs extends Task {
             // a directory
             File compileDir;
             if (destdir == null)  {
-                compileDir = File.createTempFile("precompileJsp", "");
+                compileDir = File.createTempFile("compileJsp", "");
                 compileDir.delete();
             } else {
                 compileDir = new File(destdir, ".wlp.jsp.tmp");
@@ -70,10 +70,10 @@ public class CompileJSPs extends Task {
                     server.setOperation("start");
                     server.execute();
 
-                    checkFeaturesExist(serverDir);
-
                     boolean compileSuccess = false;
                     try {
+                        checkFeaturesExist(serverDir);
+
                         compileSuccess = waitForCompilation(serverDir, jspCompileDir, war);
                     } finally {
                         // Stop the server
@@ -97,19 +97,6 @@ public class CompileJSPs extends Task {
                 delete(compileDir);
             }
         } catch (IOException e) {
-            try {
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                PrintStream ps = new PrintStream(out);
-                e.printStackTrace(ps);
-                BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(new ByteArrayInputStream(out.toByteArray())));
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    log(line);
-                }
-            } catch (IOException ioe2) {
-
-            }
             throw new BuildException("A failure occurred: " + e.toString(), e);
         }
 
@@ -346,7 +333,7 @@ public class CompileJSPs extends Task {
         } else {
             ps.println("<webApplication name=\"jspCompile\" location=\"fake.war\"/>");
         }
-        ps.println("<httpEndpoint id=\"defaultHttpEndpoint\" httpPort=\"0\"/>");
+        ps.println("<httpEndpoint id=\"defaultHttpEndpoint\" host=\"localhost\" httpPort=\"0\"/>");
         ps.print("<jspEngine prepareJsps=\"0\" scratchdir=\"" + serverDir.getAbsolutePath()
                 + "/jsps\" jdkSourceLevel=\"" + source + "\"/>");
         ps.println("<webContainer deferServletLoad=\"false\"/>");

--- a/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
+++ b/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
@@ -22,189 +22,253 @@ import java.util.zip.ZipInputStream;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
+import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.taskdefs.War;
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.ZipFileSet;
 
 import net.wasdev.wlp.ant.ServerTask;
 
 public class CompileJSPs extends Task {
 
-  private File wlpHome;
-  private File war;
-  private String ref;
-  private List<String> features = new ArrayList<>();
-  private String featureVersion = "2.3";
-  
-  public void execute() {
-    try {
-      // Need somewhere to compile to so create a tmp file and turn it to a directory
-      File compileDir = File.createTempFile("precompileJsp", "");
-      compileDir.delete();
-      try {
-        File serverDir = new File(compileDir, "servers/defaultServer/");
-        File jspCompileDir = new File(serverDir, "jsps/default_node/SMF_WebContainer/jspCompile/" + trimExtension(war.getName()));
-        if (serverDir.mkdirs()) {
-          writeServerXML(serverDir, war);
-          // Compile jsps by having the server start with eager app start and compilation
-          ServerTask server = createServerTask(compileDir);
-          server.setOperation("start");
-          server.execute();
+    private File wlpHome;
+    private File war;
+    private String ref;
+    private List<String> features = new ArrayList<>();
+    private String featureVersion = "2.3";
 
-          checkFeaturesExist(serverDir);
+    private File srcdir;
+    private File destdir;
+    private String classpath = "";
+    private String classpathRef;
+    private String source;
 
-          boolean compileSuccess = false;
-          try {
-              compileSuccess = waitForCompilation(serverDir, jspCompileDir, war);
-          } finally {
-              // Stop the server
-              server.setOperation("stop");
-              server.execute();
-          }
-          if (compileSuccess) {
-              // Finally need to merge the compiled jsps in
-              War warTask = new War();
-              warTask.setProject(getProject());
-              warTask.setDestFile(war);
-              warTask.setUpdate(true);
-              ZipFileSet jspFiles = new ZipFileSet();
-              // The JSPs will be in the a well known location. The app name from server.xml and the war file name will be
-              // in the path, the war name minus the .war extension (if present) will also be used.
-              jspFiles.setDir(jspCompileDir);
-              // The JSPs are in the package com.ibm._jsp, but they are not compiled into that structure, so make sure it goes
-              // into the war with that prefix. Note we are calling addZipfileset here because using addClasses on the War task
-              // doesn't use the prefix, so instead we set a zip fileset and specify the full path into the war.
-              jspFiles.setPrefix("WEB-INF/classes/com/ibm/_jsp/");
-              warTask.addZipfileset(jspFiles);
-              warTask.setTaskName(getTaskName());
-              warTask.execute();
-          } else {
-              printCompileErrors(new File(serverDir, "logs/console.log"));
-              throw new BuildException("JSP compile failed");
-          }
-        } else {
-          throw new BuildException("Unable to create folder for usr dir");
-        }
-      } finally {
-        delete(compileDir);
-      }
-    } catch (IOException e) {
+    public void execute() {
+        validate();
         try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            PrintStream ps = new PrintStream(out);
-            e.printStackTrace(ps);
-            BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(out.toByteArray())));
+            // Need somewhere to compile to so create a tmp file and turn it to
+            // a directory
+            File compileDir;
+            if (destdir == null)  {
+                compileDir = File.createTempFile("precompileJsp", "");
+                compileDir.delete();
+            } else {
+                compileDir = new File(destdir, ".wlp.jsp.tmp");
+            }
+            try {
+                File serverDir = new File(compileDir, "servers/defaultServer/");
+                String warSuffix = (war == null) ? "fake" : trimExtension(war.getName());
+                File jspCompileDir = new File(serverDir,
+                        "jsps/default_node/SMF_WebContainer/jspCompile/" + warSuffix);
+                if (serverDir.exists() || serverDir.mkdirs()) {
+                    writeServerXML(serverDir);
+                    createAppXML(serverDir);
+                    // Compile jsps by having the server start with eager app
+                    // start and compilation
+                    ServerTask server = createServerTask(compileDir);
+                    server.setOperation("start");
+                    server.execute();
+
+                    checkFeaturesExist(serverDir);
+
+                    boolean compileSuccess = false;
+                    try {
+                        compileSuccess = waitForCompilation(serverDir, jspCompileDir, war);
+                    } finally {
+                        // Stop the server
+                        server.setOperation("stop");
+                        server.execute();
+                    }
+                    if (compileSuccess) {
+                        if (war != null) {
+                            updateSourceWar(jspCompileDir);
+                        } else {
+                            copyClassFiles(jspCompileDir);
+                        }
+                    } else {
+                        printCompileErrors(new File(serverDir, "logs/console.log"));
+                        throw new BuildException("JSP compile failed");
+                    }
+                } else {
+                    throw new BuildException("Unable to create folder for usr dir");
+                }
+            } finally {
+                delete(compileDir);
+            }
+        } catch (IOException e) {
+            try {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                PrintStream ps = new PrintStream(out);
+                e.printStackTrace(ps);
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(new ByteArrayInputStream(out.toByteArray())));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    log(line);
+                }
+            } catch (IOException ioe2) {
+
+            }
+            throw new BuildException("A failure occurred: " + e.toString(), e);
+        }
+
+    }
+
+    private void copyClassFiles(File jspCompileDir) {
+        Copy copy = new Copy();
+        copy.setProject(getProject());
+        copy.setTaskName(getTaskName());
+        File dir = new File(destdir, "com/ibm/_jsp");
+        dir.mkdirs();
+        copy.setTodir(dir);
+        FileSet files = new FileSet();
+        files.setDir(jspCompileDir);
+        files.setIncludes("**/*.class");
+        copy.addFileset(files);
+        copy.execute();
+    }
+
+    private void updateSourceWar(File jspCompileDir) {
+        // Finally need to merge the compiled jsps in
+        War warTask = new War();
+        warTask.setProject(getProject());
+        warTask.setDestFile(war);
+        warTask.setUpdate(true);
+        ZipFileSet jspFiles = new ZipFileSet();
+        // The JSPs will be in the a well known location. The
+        // app name from server.xml and the war file name will
+        // be
+        // in the path, the war name minus the .war extension
+        // (if present) will also be used.
+        jspFiles.setDir(jspCompileDir);
+        // The JSPs are in the package com.ibm._jsp, but they
+        // are not compiled into that structure, so make sure it
+        // goes
+        // into the war with that prefix. Note we are calling
+        // addZipfileset here because using addClasses on the
+        // War task
+        // doesn't use the prefix, so instead we set a zip
+        // fileset and specify the full path into the war.
+        jspFiles.setPrefix("WEB-INF/classes/com/ibm/_jsp/");
+        warTask.addZipfileset(jspFiles);
+        warTask.setTaskName(getTaskName());
+        warTask.execute();
+    }
+
+    private void validate() {
+        if (war == null && srcdir == null) {
+            throw new BuildException("One of war or srcdir must be specified");
+        }
+
+        if (srcdir != null && destdir == null) {
+            throw new BuildException("The destdir must be specified");
+        }
+        
+        if (wlpHome == null) {
+            throw new BuildException("Liberty installation directory must be set");
+        }
+
+        if (source == null) {
+            setSource(System.getProperty("java.specification.version"));
+        }
+    }
+
+    private void checkFeaturesExist(File serverDir) {
+        BufferedReader reader = null;
+        boolean fail = false;
+        try {
+            reader = new BufferedReader(new FileReader(new File(serverDir, "logs/console.log")));
             String line;
             while ((line = reader.readLine()) != null) {
-                log(line);
+                if (line.contains("CWWKF0001E")) {
+                    log(line);
+                    fail = true;
+                }
             }
-        } catch (IOException ioe2) {
-            
+        } catch (IOException e) {
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException ioe) {
+                }
+            }
         }
-        throw new BuildException("A failure occurred: " + e.toString(), e);
-    }
-    
-  }
-  
-  private void checkFeaturesExist(File serverDir) {
-      BufferedReader reader = null;
-      boolean fail = false;
-      try {
-          reader = new BufferedReader(new FileReader(new File(serverDir, "logs/console.log")));
-          String line;
-          while ((line = reader.readLine()) != null) {
-              if (line.contains("CWWKF0001E")) {
-                  log(line);
-                  fail = true;
-              }
-          }
-      } catch (IOException e) {
-    } finally {
-          if (reader != null) {
-              try {
-                  reader.close();
-              } catch (IOException ioe) {
-              }
-          }
-    }
-      
-    if (fail) {
-        throw new BuildException("Features required to compile are missing");
-    }
-  }
 
-  private void printCompileErrors(File log) {
-    try {
-      BufferedReader reader = new BufferedReader(new FileReader(log));
-      try {
-          String line;
-          boolean reprint = false;
-          while ((line = reader.readLine()) != null) {
-              if (line.startsWith("JSPG0049E") || line.startsWith("JSPG0091E") || line.startsWith("JSPG0093E")) {
-                  reprint = true;
-              }
-              if (line.startsWith("[")) {
-                  reprint = false;
-              }
-              
-              if (reprint) {
-                  log(line, Project.MSG_ERR);
-              }
-          }
-      } finally {
-          reader.close();
-      }
-    } catch (IOException ioe) {
-        throw new BuildException("Unable to load compile log");
+        if (fail) {
+            throw new BuildException("Features required to compile are missing");
+        }
     }
-  }
 
-  private boolean waitForCompilation(File serverDir, File jspCompileDir, File war2) throws IOException {
-      ZipInputStream zipIn = new ZipInputStream(new FileInputStream(war2));
-      
-      try {
-          // Find all the jsps in the war file and work out where the compiled result should be
-          List<File> jsps = new ArrayList<>();
-          ZipEntry entry;
-          while ((entry = zipIn.getNextEntry()) != null) {
-              String entryName = entry.getName();
-              if (entryName.endsWith(".jsp")) {
-                  String expectedJSPName = '_' + entryName.substring(0, entryName.length() - 4) + ".class";
-                  jsps.add(new File(jspCompileDir, expectedJSPName));
-              }
-          }
-          
-          Set<File> javaFiles = new HashSet<>();
-          
-          boolean equalDetected = false;
-          // Only check 30 times so we aren't waiting stupidly long. This might be bad for really big apps, but an escape is needed
-          // in case something goes horribly wrong.
-          for (int i = 0; i < 30; i++) {
-              if (jspCompileDir.exists()) {
-                  // Look to see if the class file exists yet.
-                  Iterator<File> it = jsps.iterator();
-                  while (it.hasNext()) {
-                      File classFile = it.next();
-                      if (classFile.exists()) {
-                          it.remove();
-                          equalDetected = false;
-                      } 
-                      String classFileName = classFile.getName();
-                      String javaFileName = classFileName.substring(0, classFileName.length() - 6);
-                      File javaFile = new File(classFile.getParentFile(), javaFileName);
-                      // If the class file doesn't exist yet look to see if a .java file exists which might indicate
-                      // a compile failure and store it away.
-                      if (javaFile.exists()) {
-                          if (javaFiles.add(javaFile)) {
-                              equalDetected = false;
-                          }
-                      } else {
-                          if (javaFiles.remove(javaFile)) {
-                              equalDetected = false;
-                          }
-                      }
-                  }
-              }
-              if (!!!equalDetected) {
+    private void printCompileErrors(File log) {
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(log));
+            try {
+                String line;
+                boolean reprint = false;
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("JSPG0049E") || line.startsWith("JSPG0091E") || line.startsWith("JSPG0093E")) {
+                        reprint = true;
+                    }
+                    if (line.startsWith("[")) {
+                        reprint = false;
+                    }
+
+                    if (reprint) {
+                        log(line, Project.MSG_ERR);
+                    }
+                }
+            } finally {
+                reader.close();
+            }
+        } catch (IOException ioe) {
+            throw new BuildException("Unable to load compile log");
+        }
+    }
+
+    private boolean waitForCompilation(File serverDir, File jspCompileDir, File war2) throws IOException {
+        List<File> jsps = new ArrayList<>();
+
+        if (war2 != null) {
+            fillFromWar(jsps, war2, jspCompileDir);
+        } else {
+            fillFromSource(jsps, srcdir, jspCompileDir);
+        }
+        Set<File> javaFiles = new HashSet<>();
+
+        boolean equalDetected = false;
+        // Only check 30 times so we aren't waiting stupidly long. This
+        // might be bad for really big apps, but an escape is needed
+        // in case something goes horribly wrong.
+        for (int i = 0; i < 30; i++) {
+            if (jspCompileDir.exists()) {
+                // Look to see if the class file exists yet.
+                Iterator<File> it = jsps.iterator();
+                while (it.hasNext()) {
+                    File classFile = it.next();
+                    if (classFile.exists()) {
+                        it.remove();
+                        equalDetected = false;
+                    }
+                    String classFileName = classFile.getName();
+                    String javaFileName = classFileName.substring(0, classFileName.length() - 6) + ".java";
+                    File javaFile = new File(classFile.getParentFile(), javaFileName);
+                    // If the class file doesn't exist yet look to see if a
+                    // .java file exists which might indicate
+                    // a compile failure and store it away.
+                    if (javaFile.exists()) {
+                        if (javaFiles.add(javaFile)) {
+                            equalDetected = false;
+                        }
+                    } else {
+                        if (javaFiles.remove(javaFile)) {
+                            equalDetected = false;
+                        }
+                    }
+                }
+            }
+            if (!!!equalDetected) {
                 equalDetected = jsps.size() == javaFiles.size();
                 if (jsps.isEmpty()) {
                     break;
@@ -214,89 +278,195 @@ public class CompileJSPs extends Task {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
                 }
-              } else {
-                  break;
-              }
-          }
-      } finally {
-          zipIn.close();
-      }
-      
-      return true;
-    
-  }
-
-  private ServerTask createServerTask(File usrDir) {
-      ServerTask server = new ServerTask();
-      server.setProject(getProject());
-      server.setRef(ref);
-      server.setInstallDir(wlpHome);
-      server.setUserDir(usrDir);
-      server.setTaskName(getTaskName());
-      return server;
-  }
-
-  private void writeServerXML(File serverDir, File war2) throws FileNotFoundException {
-      PrintStream ps = new PrintStream(new File(serverDir, "server.xml"));
-      ps.println("<server>");
-      ps.println("<featureManager>");
-      for (String feature : features) {
-          ps.print("<feature>");
-          ps.print(feature);
-          ps.println("</feature>");
-      }
-      ps.print("<feature>jsp-");
-      ps.print(featureVersion);
-      ps.println("</feature>");
-      ps.println("</featureManager>");
-      ps.println("<webApplication name=\"jspCompile\" location=\"" + war.getAbsolutePath() + "\"/>");
-      ps.println("<httpEndpoint id=\"defaultHttpEndpoint\" httpPort=\"0\"/>");
-      ps.println("<jspEngine prepareJsps=\"0\" scratchdir=\"" + serverDir.getAbsolutePath() + "/jsps\"/>");
-      ps.println("<webContainer deferServletLoad=\"false\"/>");
-      ps.println("<keyStore password=\"dummyKeystore\"/>");
-      ps.println("</server>");
-      ps.close();
-  }
-
-  private String trimExtension(String name) {
-    if (name.endsWith(".war")) {
-        return name.substring(0, name.length() - 4);
-    }
-    return name;
-  }
-
-  private void delete(File f) {
-    if (f.isFile()) {
-      f.delete();
-    } else if (f.isDirectory()) {
-      File[] files = f.listFiles();
-      if (files != null) {
-        for (File file : files) {
-          delete(file);
+            } else {
+                break;
+            }
         }
-      }
-      f.delete();
-    }
-  }
 
-  public void setInstallDir(File home) {
-    wlpHome = home;
-  }
-  
-  public void setRef(String ref) {
-    this.ref = ref;
-  }
-  
-  public void setWar(File war) {
-    this.war = war;
-  }
-  
-  public void setFeatures(String features) {
-      String[] featuresArray = features.split(",");
-      this.features.addAll(Arrays.asList(featuresArray));
-  }
-  
-  public void setJspVersion(String version) {
-      featureVersion = version;
-  }
+        return jsps.isEmpty();
+
+    }
+
+    private void fillFromSource(List<File> jsps, File srcdir2, File jspCompileDir) {
+        File[] files = srcdir2.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                String fileName = file.getName();
+                if (file.isFile() && fileName.endsWith(".jsp")) {
+                    String expectedJSPName = '_' + fileName.substring(0, fileName.length() - 4) + ".class";
+                    jsps.add(new File(jspCompileDir, expectedJSPName));
+                } else if (file.isDirectory()) {
+                    fillFromSource(jsps, file, new File(jspCompileDir, file.getName()));
+                }
+            }
+        }
+    }
+
+    private void fillFromWar(List<File> jsps, File war2, File jspCompileDir) {
+        ZipInputStream zipIn = null;
+        try {
+            zipIn = new ZipInputStream(new FileInputStream(war2));
+
+            // Find all the jsps in the war file and work out where the compiled
+            // result should be
+            ZipEntry entry;
+            while ((entry = zipIn.getNextEntry()) != null) {
+                String entryName = entry.getName();
+                if (entryName.endsWith(".jsp")) {
+                    String expectedJSPName = '_' + entryName.substring(0, entryName.length() - 4) + ".class";
+                    jsps.add(new File(jspCompileDir, expectedJSPName));
+                }
+            }
+        } catch (IOException ioe) {
+        } finally {
+            if (zipIn != null) {
+                try {
+                    zipIn.close();
+                } catch (IOException ioe) {
+                }
+            }
+        }
+    }
+
+    private ServerTask createServerTask(File usrDir) {
+        ServerTask server = new ServerTask();
+        server.setProject(getProject());
+        server.setRef(ref);
+        server.setInstallDir(wlpHome);
+        server.setUserDir(usrDir);
+        server.setTaskName(getTaskName());
+        return server;
+    }
+
+    private void writeServerXML(File serverDir) throws FileNotFoundException {
+        PrintStream ps = new PrintStream(new File(serverDir, "server.xml"));
+        ps.println("<server>");
+        ps.println("<featureManager>");
+        for (String feature : features) {
+            ps.print("<feature>");
+            ps.print(feature);
+            ps.println("</feature>");
+        }
+        ps.print("<feature>jsp-");
+        ps.print(featureVersion);
+        ps.println("</feature>");
+        ps.println("</featureManager>");
+        if (war != null) {
+            ps.println("<webApplication name=\"jspCompile\" location=\"" + war.getAbsolutePath() + "\"/>");
+        } else {
+            ps.println("<webApplication name=\"jspCompile\" location=\"fake.war\"/>");
+        }
+        ps.println("<httpEndpoint id=\"defaultHttpEndpoint\" httpPort=\"0\"/>");
+        ps.print("<jspEngine prepareJsps=\"0\" scratchdir=\"" + serverDir.getAbsolutePath()
+                + "/jsps\" jdkSourceLevel=\"" + source + "\"/>");
+        ps.println("<webContainer deferServletLoad=\"false\"/>");
+        ps.println("<keyStore password=\"dummyKeystore\"/>");
+        ps.println("</server>");
+        ps.close();
+    }
+
+    private void createAppXML(File serverDir) throws FileNotFoundException {
+        if (srcdir != null) {
+            // TODO write the loose application xml.
+            File appsDir = new File(serverDir, "apps");
+            appsDir.mkdirs();
+            PrintStream ps = new PrintStream(new File(appsDir, "fake.war.xml"));
+            ps.println("<archive>");
+            ps.println("  <dir targetInArchive=\"/\" sourceOnDisk=\"" + srcdir.getAbsolutePath() + "\"/>");
+
+            Path p = new Path(getProject(), classpath);
+            if (classpathRef != null) {
+                Path path = (Path) getProject().getReference(classpathRef);
+                p.add(path);
+            }
+            String[] cp = p.toString().split(File.pathSeparator);
+            for (String entry : cp) {
+                File f = new File(entry);
+                if (f.isFile() && f.exists() && f.getName().endsWith(".jar")) {
+                    ps.println(
+                            "  <file targetInArchive=\"WEB-INF/lib\" sourceOnDisk=\"" + f.getAbsolutePath() + "\"/>");
+                } else if (f.isDirectory() && f.exists()) {
+                    ps.println("  <file targetInArchive=\"WEB-INF/classes\" sourceOnDisk=\"" + f.getAbsolutePath()
+                            + "\"/>");
+                }
+            }
+
+            ps.println("</archive>");
+            ps.close();
+        }
+    }
+
+    private String trimExtension(String name) {
+        if (name.endsWith(".war")) {
+            return name.substring(0, name.length() - 4);
+        }
+        return name;
+    }
+
+    private void delete(File f) {
+        if (f.isFile()) {
+            f.delete();
+        } else if (f.isDirectory()) {
+            File[] files = f.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    delete(file);
+                }
+            }
+            f.delete();
+        }
+    }
+
+    public void setInstallDir(File home) {
+        wlpHome = home;
+    }
+
+    public void setRef(String ref) {
+        this.ref = ref;
+    }
+
+    public void setWar(File war) {
+        this.war = war;
+    }
+
+    public void setFeatures(String features) {
+        String[] featuresArray = features.split(",");
+        this.features.addAll(Arrays.asList(featuresArray));
+    }
+
+    public void setJspVersion(String version) {
+        featureVersion = version;
+    }
+
+    public void setSrcdir(File srcdir) {
+        this.srcdir = srcdir;
+    }
+
+    public void setDestdir(File destdir) {
+        this.destdir = destdir;
+    }
+
+    public void setClasspath(String classpath) {
+        this.classpath = classpath;
+    }
+
+    public void setClasspathRef(String classpathRef) {
+        this.classpathRef = classpathRef;
+    }
+
+    public void setSource(String src) {
+        if ("1.3".equals(src)) {
+            source = "13";
+        } else if ("1.4".equals(src)) {
+            source = "14";
+        } else if ("1.5".equals(src) || "5".equals(src)) {
+            source = "15";
+        } else if ("1.6".equals(src) || "6".equals(src)) {
+            source = "16";
+        } else if ("1.7".equals(src) || "7".equals(src)) {
+            source = "17";
+        } else if ("1.8".equals(src) || "8".equals(src)) {
+            source = "18";
+        }
+    }
 }

--- a/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
+++ b/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
@@ -1,0 +1,302 @@
+package net.wasdev.wlp.ant.jsp;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.taskdefs.War;
+import org.apache.tools.ant.types.ZipFileSet;
+
+import net.wasdev.wlp.ant.ServerTask;
+
+public class CompileJSPs extends Task {
+
+  private File wlpHome;
+  private File war;
+  private String ref;
+  private List<String> features = new ArrayList<>();
+  private String featureVersion = "2.3";
+  
+  public void execute() {
+    try {
+      // Need somewhere to compile to so create a tmp file and turn it to a directory
+      File compileDir = File.createTempFile("precompileJsp", "");
+      compileDir.delete();
+      try {
+        File serverDir = new File(compileDir, "servers/defaultServer/");
+        File jspCompileDir = new File(serverDir, "jsps/default_node/SMF_WebContainer/jspCompile/" + trimExtension(war.getName()));
+        if (serverDir.mkdirs()) {
+          writeServerXML(serverDir, war);
+          // Compile jsps by having the server start with eager app start and compilation
+          ServerTask server = createServerTask(compileDir);
+          server.setOperation("start");
+          server.execute();
+
+          checkFeaturesExist(serverDir);
+
+          boolean compileSuccess = false;
+          try {
+              compileSuccess = waitForCompilation(serverDir, jspCompileDir, war);
+          } finally {
+              // Stop the server
+              server.setOperation("stop");
+              server.execute();
+          }
+          if (compileSuccess) {
+              // Finally need to merge the compiled jsps in
+              War warTask = new War();
+              warTask.setProject(getProject());
+              warTask.setDestFile(war);
+              warTask.setUpdate(true);
+              ZipFileSet jspFiles = new ZipFileSet();
+              // The JSPs will be in the a well known location. The app name from server.xml and the war file name will be
+              // in the path, the war name minus the .war extension (if present) will also be used.
+              jspFiles.setDir(jspCompileDir);
+              // The JSPs are in the package com.ibm._jsp, but they are not compiled into that structure, so make sure it goes
+              // into the war with that prefix. Note we are calling addZipfileset here because using addClasses on the War task
+              // doesn't use the prefix, so instead we set a zip fileset and specify the full path into the war.
+              jspFiles.setPrefix("WEB-INF/classes/com/ibm/_jsp/");
+              warTask.addZipfileset(jspFiles);
+              warTask.setTaskName(getTaskName());
+              warTask.execute();
+          } else {
+              printCompileErrors(new File(serverDir, "logs/console.log"));
+              throw new BuildException("JSP compile failed");
+          }
+        } else {
+          throw new BuildException("Unable to create folder for usr dir");
+        }
+      } finally {
+        delete(compileDir);
+      }
+    } catch (IOException e) {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(out);
+            e.printStackTrace(ps);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(out.toByteArray())));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                log(line);
+            }
+        } catch (IOException ioe2) {
+            
+        }
+        throw new BuildException("A failure occurred: " + e.toString(), e);
+    }
+    
+  }
+  
+  private void checkFeaturesExist(File serverDir) {
+      BufferedReader reader = null;
+      boolean fail = false;
+      try {
+          reader = new BufferedReader(new FileReader(new File(serverDir, "logs/console.log")));
+          String line;
+          while ((line = reader.readLine()) != null) {
+              if (line.contains("CWWKF0001E")) {
+                  log(line);
+                  fail = true;
+              }
+          }
+      } catch (IOException e) {
+    } finally {
+          if (reader != null) {
+              try {
+                  reader.close();
+              } catch (IOException ioe) {
+              }
+          }
+    }
+      
+    if (fail) {
+        throw new BuildException("Features required to compile are missing");
+    }
+  }
+
+  private void printCompileErrors(File log) {
+    try {
+      BufferedReader reader = new BufferedReader(new FileReader(log));
+      try {
+          String line;
+          boolean reprint = false;
+          while ((line = reader.readLine()) != null) {
+              if (line.startsWith("JSPG0049E") || line.startsWith("JSPG0091E") || line.startsWith("JSPG0093E")) {
+                  reprint = true;
+              }
+              if (line.startsWith("[")) {
+                  reprint = false;
+              }
+              
+              if (reprint) {
+                  log(line, Project.MSG_ERR);
+              }
+          }
+      } finally {
+          reader.close();
+      }
+    } catch (IOException ioe) {
+        throw new BuildException("Unable to load compile log");
+    }
+  }
+
+  private boolean waitForCompilation(File serverDir, File jspCompileDir, File war2) throws IOException {
+      ZipInputStream zipIn = new ZipInputStream(new FileInputStream(war2));
+      
+      try {
+          // Find all the jsps in the war file and work out where the compiled result should be
+          List<File> jsps = new ArrayList<>();
+          ZipEntry entry;
+          while ((entry = zipIn.getNextEntry()) != null) {
+              String entryName = entry.getName();
+              if (entryName.endsWith(".jsp")) {
+                  String expectedJSPName = '_' + entryName.substring(0, entryName.length() - 4) + ".class";
+                  jsps.add(new File(jspCompileDir, expectedJSPName));
+              }
+          }
+          
+          Set<File> javaFiles = new HashSet<>();
+          
+          boolean equalDetected = false;
+          // Only check 30 times so we aren't waiting stupidly long. This might be bad for really big apps, but an escape is needed
+          // in case something goes horribly wrong.
+          for (int i = 0; i < 30; i++) {
+              if (jspCompileDir.exists()) {
+                  // Look to see if the class file exists yet.
+                  Iterator<File> it = jsps.iterator();
+                  while (it.hasNext()) {
+                      File classFile = it.next();
+                      if (classFile.exists()) {
+                          it.remove();
+                          equalDetected = false;
+                      } 
+                      String classFileName = classFile.getName();
+                      String javaFileName = classFileName.substring(0, classFileName.length() - 6);
+                      File javaFile = new File(classFile.getParentFile(), javaFileName);
+                      // If the class file doesn't exist yet look to see if a .java file exists which might indicate
+                      // a compile failure and store it away.
+                      if (javaFile.exists()) {
+                          if (javaFiles.add(javaFile)) {
+                              equalDetected = false;
+                          }
+                      } else {
+                          if (javaFiles.remove(javaFile)) {
+                              equalDetected = false;
+                          }
+                      }
+                  }
+              }
+              if (!!!equalDetected) {
+                equalDetected = jsps.size() == javaFiles.size();
+                if (jsps.isEmpty()) {
+                    break;
+                }
+                try {
+                    // Wait for a second for compilation to progress
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                }
+              } else {
+                  break;
+              }
+          }
+      } finally {
+          zipIn.close();
+      }
+      
+      return true;
+    
+  }
+
+  private ServerTask createServerTask(File usrDir) {
+      ServerTask server = new ServerTask();
+      server.setProject(getProject());
+      server.setRef(ref);
+      server.setInstallDir(wlpHome);
+      server.setUserDir(usrDir);
+      server.setTaskName(getTaskName());
+      return server;
+  }
+
+  private void writeServerXML(File serverDir, File war2) throws FileNotFoundException {
+      PrintStream ps = new PrintStream(new File(serverDir, "server.xml"));
+      ps.println("<server>");
+      ps.println("<featureManager>");
+      for (String feature : features) {
+          ps.print("<feature>");
+          ps.print(feature);
+          ps.println("</feature>");
+      }
+      ps.print("<feature>jsp-");
+      ps.print(featureVersion);
+      ps.println("</feature>");
+      ps.println("</featureManager>");
+      ps.println("<webApplication name=\"jspCompile\" location=\"" + war.getAbsolutePath() + "\"/>");
+      ps.println("<httpEndpoint id=\"defaultHttpEndpoint\" httpPort=\"0\"/>");
+      ps.println("<jspEngine prepareJsps=\"0\" scratchdir=\"" + serverDir.getAbsolutePath() + "/jsps\"/>");
+      ps.println("<webContainer deferServletLoad=\"false\"/>");
+      ps.println("<keyStore password=\"dummyKeystore\"/>");
+      ps.println("</server>");
+      ps.close();
+  }
+
+  private String trimExtension(String name) {
+    if (name.endsWith(".war")) {
+        return name.substring(0, name.length() - 4);
+    }
+    return name;
+  }
+
+  private void delete(File f) {
+    if (f.isFile()) {
+      f.delete();
+    } else if (f.isDirectory()) {
+      File[] files = f.listFiles();
+      if (files != null) {
+        for (File file : files) {
+          delete(file);
+        }
+      }
+      f.delete();
+    }
+  }
+
+  public void setInstallDir(File home) {
+    wlpHome = home;
+  }
+  
+  public void setRef(String ref) {
+    this.ref = ref;
+  }
+  
+  public void setWar(File war) {
+    this.war = war;
+  }
+  
+  public void setFeatures(String features) {
+      String[] featuresArray = features.split(",");
+      this.features.addAll(Arrays.asList(featuresArray));
+  }
+  
+  public void setJspVersion(String version) {
+      featureVersion = version;
+  }
+}

--- a/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
+++ b/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
@@ -119,9 +119,8 @@ public class CompileJSPs extends Task {
         Copy copy = new Copy();
         copy.setProject(getProject());
         copy.setTaskName(getTaskName());
-        File dir = new File(destdir, "com/ibm/_jsp");
-        dir.mkdirs();
-        copy.setTodir(dir);
+        destdir.mkdirs();
+        copy.setTodir(destdir);
         FileSet files = new FileSet();
         files.setDir(jspCompileDir);
         files.setIncludes("**/*.class");
@@ -142,16 +141,7 @@ public class CompileJSPs extends Task {
         // in the path, the war name minus the .war extension
         // (if present) will also be used.
         jspFiles.setDir(jspCompileDir);
-        // The JSPs are in the package com.ibm._jsp, but they
-        // are not compiled into that structure, so make sure it
-        // goes
-        // into the war with that prefix. Note we are calling
-        // addZipfileset here because using addClasses on the
-        // War task
-        // doesn't use the prefix, so instead we set a zip
-        // fileset and specify the full path into the war.
-        jspFiles.setPrefix("WEB-INF/classes/com/ibm/_jsp/");
-        warTask.addZipfileset(jspFiles);
+        warTask.addClasses(jspFiles);
         warTask.setTaskName(getTaskName());
         warTask.execute();
     }

--- a/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
+++ b/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
@@ -1,14 +1,11 @@
 package net.wasdev.wlp.ant.jsp;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/resources/net/wasdev/wlp/ant/antlib.xml
+++ b/src/main/resources/net/wasdev/wlp/ant/antlib.xml
@@ -8,4 +8,5 @@
     <taskdef classname="net.wasdev.wlp.ant.UninstallFeatureTask" name="uninstall-feature" />
     <taskdef classname="net.wasdev.wlp.ant.CleanTask" name="clean" />
     <taskdef classname="net.wasdev.wlp.ant.install.InstallLibertyTask" name="install-liberty" />
+    <taskdef classname="net.wasdev.wlp.ant.jsp.CompileJSPs" name="compileJSPs"/>
 </antlib>

--- a/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
@@ -1,0 +1,52 @@
+package net.wasdev.wlp.ant.jsp;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.junit.Test;
+
+public class CompileJSPsTest {
+
+    private static class MyProject extends Project {
+
+        @Override
+        public void log(Task t, String message, int level) {
+            System.out.println(message);
+        }
+    }
+    
+    @Test
+    public void testBasicCompile() throws URISyntaxException {
+        URI url = CompileJSPsTest.class.getResource("/goodJsps/good.jsp").toURI();
+        File compileDir = new File("compiledJSPs");
+        CompileJSPs compile = new CompileJSPs();
+        compile.setProject(new MyProject());
+        compile.setSrcdir(new File(url).getParentFile());
+        compile.setDestdir(compileDir);
+        compile.setInstallDir(new File("/Users/nottinga/Documents/runtimes/8.5.5.9/wlp/"));
+        compile.execute();
+        
+        File f = new File(compileDir, "com/ibm/_jsp/_good.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+        f = new File(compileDir, "com/ibm/_jsp/childDir/_good.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+    }
+
+    @Test(expected=BuildException.class)
+    public void testCompileFailure() throws URISyntaxException {
+        URI url = CompileJSPsTest.class.getResource("/badJsps/good.jsp").toURI();
+        File compileDir = new File("compiledJSPs");
+        CompileJSPs compile = new CompileJSPs();
+        compile.setProject(new MyProject());
+        compile.setSrcdir(new File(url).getParentFile());
+        compile.setDestdir(compileDir);
+        compile.setInstallDir(new File("/Users/nottinga/Documents/runtimes/8.5.5.9/wlp/"));
+        compile.execute();
+    }
+}

--- a/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
@@ -60,9 +60,9 @@ public class CompileJSPsTest {
         URI url = CompileJSPsTest.class.getResource("/goodJsps/good.jsp").toURI();
         createTask(url).execute();
         
-        File f = new File(compileDir, "com/ibm/_jsp/_good.class");
+        File f = new File(compileDir, "_good.class");
         assertTrue("The compiled JSP should exist: " + f, f.exists());
-        f = new File(compileDir, "com/ibm/_jsp/childDir/_good.class");
+        f = new File(compileDir, "childDir/_good.class");
         assertTrue("The compiled JSP should exist: " + f, f.exists());
     }
 

--- a/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
@@ -9,10 +9,16 @@ import java.net.URISyntaxException;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import net.wasdev.wlp.ant.install.InstallLibertyTask;
 
 public class CompileJSPsTest {
 
+    private static final File installDir = new File("target/wlp");
+    private File compileDir = new File("target/compiledJSPs");;
     private static class MyProject extends Project {
 
         @Override
@@ -21,16 +27,38 @@ public class CompileJSPsTest {
         }
     }
     
+    @BeforeClass
+    public static void setup() {
+        InstallLibertyTask install = new InstallLibertyTask();
+        install.setProject(new Project());
+        install.setBaseDir(installDir.getAbsolutePath());
+        install.setType("webProfile7");
+        install.execute();
+    }
+    
+    @AfterClass
+    public static void tearDown() {
+        delete(installDir);
+    }
+
+    private static void delete(File f) {
+        if (f.isFile()) {
+            f.delete();
+        } else if (f.isDirectory()) {
+            File[] files = f.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    delete(file);
+                }
+            }
+            f.delete();
+        }
+    }
+
     @Test
     public void testBasicCompile() throws URISyntaxException {
         URI url = CompileJSPsTest.class.getResource("/goodJsps/good.jsp").toURI();
-        File compileDir = new File("compiledJSPs");
-        CompileJSPs compile = new CompileJSPs();
-        compile.setProject(new MyProject());
-        compile.setSrcdir(new File(url).getParentFile());
-        compile.setDestdir(compileDir);
-        compile.setInstallDir(new File("/Users/nottinga/Documents/runtimes/8.5.5.9/wlp/"));
-        compile.execute();
+        createTask(url).execute();
         
         File f = new File(compileDir, "com/ibm/_jsp/_good.class");
         assertTrue("The compiled JSP should exist: " + f, f.exists());
@@ -38,15 +66,18 @@ public class CompileJSPsTest {
         assertTrue("The compiled JSP should exist: " + f, f.exists());
     }
 
-    @Test(expected=BuildException.class)
-    public void testCompileFailure() throws URISyntaxException {
-        URI url = CompileJSPsTest.class.getResource("/badJsps/good.jsp").toURI();
-        File compileDir = new File("compiledJSPs");
+    private CompileJSPs createTask(URI url) {
         CompileJSPs compile = new CompileJSPs();
         compile.setProject(new MyProject());
         compile.setSrcdir(new File(url).getParentFile());
         compile.setDestdir(compileDir);
-        compile.setInstallDir(new File("/Users/nottinga/Documents/runtimes/8.5.5.9/wlp/"));
-        compile.execute();
+        compile.setInstallDir(new File(installDir, "wlp"));
+        return compile;
+    }
+
+    @Test(expected=BuildException.class)
+    public void testCompileFailure() throws URISyntaxException {
+        URI url = CompileJSPsTest.class.getResource("/badJsps/good.jsp").toURI();
+        createTask(url).execute();
     }
 }

--- a/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
@@ -9,6 +9,7 @@ import java.net.URISyntaxException;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -26,7 +27,7 @@ public class CompileJSPsTest {
             System.out.println(message);
         }
     }
-    
+
     @BeforeClass
     public static void setup() {
         InstallLibertyTask install = new InstallLibertyTask();
@@ -35,10 +36,15 @@ public class CompileJSPsTest {
         install.setType("webProfile7");
         install.execute();
     }
-    
+
     @AfterClass
     public static void tearDown() {
         delete(installDir);
+    }
+
+    @After
+    public void cleanCompileDir() {
+        delete(compileDir);
     }
 
     private static void delete(File f) {

--- a/src/test/resources/badJsps/bad.jsp
+++ b/src/test/resources/badJsps/bad.jsp
@@ -1,0 +1,12 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+      <p>Inserted compile issue <%=Collections.emptySet() %>
+  </body>
+</html>

--- a/src/test/resources/badJsps/good.jsp
+++ b/src/test/resources/badJsps/good.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/childDir/good.jsp
+++ b/src/test/resources/goodJsps/childDir/good.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/good.jsp
+++ b/src/test/resources/goodJsps/good.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>


### PR DESCRIPTION
#65 Create a new ant task to precompile JSPs. There is no separate JSP compiler, but the server can compile JSPs at runtime, so the task will start a server, deploy the application to it, wait for the jsps to compile, stop the server and finally then package them up in the war file.