### PR TITLE
Fixed JspCompile for more complex scenarios

### DIFF
--- a/docs/compileJSPs.md
+++ b/docs/compileJSPs.md
@@ -17,6 +17,7 @@ Parameters supported by this task in addition to the [common parameters](common-
 | features | A comma separated list of Liberty features that are required to compile the JSPs | No
 | classpath | The classpath required to compile the JSPs | No
 | classpathref | A ref to a path for compiling the JSPs | No
+| timeout | Stop the server if jsp compile isn't finish within the specified time (given in seconds). Default: 30 sec | No
 | tmpdir | The path where a temporary Liberty server directory is created. Default is system tmp directory. | No
 | cleanup | Whether the temporary Liberty server directory should be deleted afterwards. Default: `true` | No
 

--- a/docs/compileJSPs.md
+++ b/docs/compileJSPs.md
@@ -17,6 +17,12 @@ Parameters supported by this task in addition to the [common parameters](common-
 | features | A comma separated list of Liberty features that are required to compile the JSPs | No
 | classpath | The classpath required to compile the JSPs | No
 | classpathref | A ref to a path for compiling the JSPs | No
+| tmpdir | The path where a temporary Liberty server directory is created. Default is system tmp directory. | No
+| cleanup | Whether the temporary Liberty server directory should be deleted afterwards. Default: `true` | No
+
+**Note:** If the attribute `tmpdir` is not given, this task will create a a random directory for the temporary Liberty server in the system tmp dir.
+Something line `/tmp/compileJsp7857999246295419245`. If `tmpdir` is given, the name is always `${tmpdir}/jspCompile` (without random digits).
+Short: If you set the attribute `tmpdir` it must be project-specific, so that multiple parallel builds don't influence each other.
 
 
 #### Examples

--- a/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
+++ b/src/main/java/net/wasdev/wlp/ant/jsp/CompileJSPs.java
@@ -45,6 +45,9 @@ public class CompileJSPs extends Task {
     private String classpathRef;
     private String source;
 
+    // By default allow 30 seconds to compile the jsps
+    private int timeout = 30;
+
     @Override
     public void execute() {
         validate();
@@ -223,10 +226,9 @@ public class CompileJSPs extends Task {
         Set<File> javaFiles = new HashSet<>();
 
         boolean equalDetected = false;
-        // Only check 30 times so we aren't waiting stupidly long. This
-        // might be bad for really big apps, but an escape is needed
-        // in case something goes horribly wrong.
-        for (int i = 0; i < 30; i++) {
+
+        // Allow timeout seconds to compile the jsps. 
+        for (int i = 0; i < timeout; i++) {
             if (jspCompileDir.exists()) {
                 // Look to see if the class file exists yet.
                 Iterator<File> it = jsps.iterator();
@@ -484,5 +486,9 @@ public class CompileJSPs extends Task {
         } else if ("1.8".equals(src) || "8".equals(src)) {
             source = "18";
         }
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
     }
 }

--- a/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
+++ b/src/test/java/net/wasdev/wlp/ant/jsp/CompileJSPsTest.java
@@ -20,6 +20,7 @@ public class CompileJSPsTest {
 
     private static final File installDir = new File("target/wlp");
     private File compileDir = new File("target/compiledJSPs");;
+
     private static class MyProject extends Project {
 
         @Override
@@ -65,10 +66,25 @@ public class CompileJSPsTest {
     public void testBasicCompile() throws URISyntaxException {
         URI url = CompileJSPsTest.class.getResource("/goodJsps/good.jsp").toURI();
         createTask(url).execute();
-        
+
         File f = new File(compileDir, "_good.class");
         assertTrue("The compiled JSP should exist: " + f, f.exists());
         f = new File(compileDir, "childDir/_good.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+
+        f = new File(compileDir, "_switch.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+        f = new File(compileDir, "childDir/_switch.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+
+        f = new File(compileDir, "_X_2D__5F__2B__2E__20AC__25_.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+        f = new File(compileDir, "childDir/_X_2D__5F__2B__2E__20AC__25_.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+
+        f = new File(compileDir, "_ÄÖÜäöüß.class");
+        assertTrue("The compiled JSP should exist: " + f, f.exists());
+        f = new File(compileDir, "childDir/_ÄÖÜäöüß.class");
         assertTrue("The compiled JSP should exist: " + f, f.exists());
     }
 
@@ -81,7 +97,7 @@ public class CompileJSPsTest {
         return compile;
     }
 
-    @Test(expected=BuildException.class)
+    @Test(expected = BuildException.class)
     public void testCompileFailure() throws URISyntaxException {
         URI url = CompileJSPsTest.class.getResource("/badJsps/good.jsp").toURI();
         createTask(url).execute();

--- a/src/test/resources/goodJsps/X-_+.€%.jsp
+++ b/src/test/resources/goodJsps/X-_+.€%.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/childDir/X-_+.€%.jsp
+++ b/src/test/resources/goodJsps/childDir/X-_+.€%.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/childDir/switch.jsp
+++ b/src/test/resources/goodJsps/childDir/switch.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/childDir/ÄÖÜäöüß.jsp
+++ b/src/test/resources/goodJsps/childDir/ÄÖÜäöüß.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/switch.jsp
+++ b/src/test/resources/goodJsps/switch.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/with-inner-class.jsp
+++ b/src/test/resources/goodJsps/with-inner-class.jsp
@@ -1,0 +1,21 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%!
+private static class JspInnerClass {
+  private final String str = "Bad Idea!";
+
+    public String getStr() {
+        return str;
+    }
+}
+%>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+      <p>Inner class in a JSP: <%=new JspInnerClass().getStr()%></p>
+  </body>
+</html>

--- a/src/test/resources/goodJsps/ÄÖÜäöüß.jsp
+++ b/src/test/resources/goodJsps/ÄÖÜäöüß.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+      <jsp:useBean id="datetime" class="java.util.Date" />
+      <title>Hello IBM WebSphere Application Server Liberty</title>
+  </head>
+  <body>
+      <h2>Welcome to IBM Liberty</h2>
+      <p>Congratulations on running this very simple demo application on ${datetime}.</p>
+  </body>
+</html>


### PR DESCRIPTION
- Fixed creation of loose-application-xml
- Fixed class file naming (with test)
- Added property "tmpdir": The directory where to create the temp Liberty
- Added property "cleanup": Whether temp Liberty should be deleted afterwards (Default: true)
- Added property "timeout": Configure JSP compile timeout (Default: 30s)
- Updated docs

DCO 1.1 Signed-off-by: Ralf Schandl <ralf.schandl@de.ibm.com>