### PR TITLE
AM Patch - Windows service and Server Log customize path

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -27,6 +27,7 @@ Parameters supported by this task in addition to the [common parameters](common-
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
+| serverLogDir | Location of the server log where the message.log file can be found. | No |
 
 #### Examples
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -5,6 +5,7 @@ The `server` task supports the following operations:
 
 * `create` - creates a named server instance.
 * `start` - starts the named server instance in background. If the server instance does not exist, this option creates one by default.
+* `startWinService` - starts the named server Windows service.
 * `run` - start the named service instance in foreground. If the server instance does not exist, this option creates one by default.
 * `stop` - stops the named server.
 * `status` - checks the server status.
@@ -18,7 +19,7 @@ Parameters supported by this task in addition to the [common parameters](common-
 
 | Attribute | Description | Required |
 | --------- | ------------ | ----------| 
-| operation | Server operations available as options: `create`, `start`, `run`, `stop`, `status`, `package`, `dump`, and `javadump`. | Yes | 
+| operation | Server operations available as options: `create`, `start`, `startWinService`, `run`, `stop`, `status`, `package`, `dump`, and `javadump`. | Yes | 
 | clean | Clean all cached information on server start up. The default value is `false`. Only used with the `start` operation. | No | 
 | timeout | Waiting time before the server starts. The default value is 30 seconds. The unit is milliseconds. Only used with the `start` operation. | No | 
 | include | A comma-delimited list of values. The valid values vary depending on the operation. For the `package` operation the valid values are `all`, `usr`, and `minify`. For the `dump` operation the valid values are `heap`, `system`, and `thread`. For the `javadump` operation the valid values are `heap` and `system`. | Yes, only when the `os` option is set |

--- a/src/main/java/net/wasdev/wlp/ant/AbstractTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/AbstractTask.java
@@ -39,19 +39,20 @@ public abstract class AbstractTask extends Task {
     protected File installDir;
     protected File userDir;
     protected File outputDir;
-    protected File serverConfigDir = null;
-    protected File serverOutputDir = null;
+    protected File serverLogDir;
     protected String serverName;
-
     protected String ref;
 
+    protected File serverConfigDir = null;
+    protected File serverOutputDir = null;
+    
     protected static String osName;
     protected static boolean isWindows;
 
     protected ProcessBuilder processBuilder;
 
     protected static final String DEFAULT_SERVER = "defaultServer";
-    protected static final String DEFAULT_LOG_FILE = "logs/messages.log";
+    protected static final String DEFAULT_LOG_FILE = "messages.log";
 
     protected static final String WLP_USER_DIR_VAR = "WLP_USER_DIR";
     protected static final String WLP_OUTPUT_DIR_VAR = "WLP_OUTPUT_DIR";
@@ -66,6 +67,7 @@ public abstract class AbstractTask extends Task {
                 setServerName(((ServerTask) serverRef).getServerName());
                 setUserDir(((ServerTask) serverRef).getUserDir());
                 setOutputDir(((ServerTask) serverRef).getOutputDir());
+                setServerLogDir(((ServerTask) serverRef).getServerLogDir());
             }
         }
 
@@ -122,6 +124,12 @@ public abstract class AbstractTask extends Task {
             }
 
             log(MessageFormat.format(messages.getString("info.variable"), "server.output.dir", serverOutputDir.getCanonicalPath()));
+            
+            if (serverLogDir == null) {
+            	serverLogDir = new File(serverOutputDir, "logs");
+            }
+            	
+            log(MessageFormat.format(messages.getString("info.variable"), "server.log.dir", serverLogDir.getCanonicalPath()));
         } catch (IOException e) {
             throw new BuildException(e);
         }
@@ -156,6 +164,14 @@ public abstract class AbstractTask extends Task {
         this.outputDir = outputDir;
     }
 
+    public File getServerLogDir() {
+        return serverLogDir;
+    }
+    
+    public void setServerLogDir(File serverLogDir) {
+        this.serverLogDir = serverLogDir;
+    }
+        
     /**
      * @return the serverName
      */
@@ -172,7 +188,7 @@ public abstract class AbstractTask extends Task {
     }
 
     public File getLogFile() {
-        return new File(serverOutputDir, DEFAULT_LOG_FILE);
+        return new File(serverLogDir, DEFAULT_LOG_FILE);
     }
 
     /**

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -98,6 +98,8 @@ public class ServerTask extends AbstractTask {
                   doRun();
               } else if ("start".equals(operation)) {
                   doStart();
+              } else if ("startWinService".equals(operation)) {
+            	  doStartWinService();
               } else if ("stop".equals(operation)) {
                   doStop();
               } else if ("status".equals(operation)) {
@@ -128,6 +130,21 @@ public class ServerTask extends AbstractTask {
             log(MessageFormat.format(messages.getString("info.server.create"), serverName));
             doCreate();
         }
+        List<String> command = getInitialCommand(operation);
+        addCleanOption(command);
+        processBuilder.command(command);
+        Process p = processBuilder.start();
+        checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue(), ReturnCode.REDUNDANT_ACTION_STATUS.getValue());
+
+        // check server started message code.
+        long startTimeout = SERVER_START_TIMEOUT_DEFAULT;
+        if (timeout != null && !timeout.equals("")) {
+            startTimeout = Long.valueOf(timeout);
+        }
+        validateServerStarted(getLogFile(), startTimeout);
+    }
+    
+    private void doStartWinService() throws Exception {
         List<String> command = getInitialCommand(operation);
         addCleanOption(command);
         processBuilder.command(command);


### PR DESCRIPTION
On Windows Server, the liberty server can be managed by a Windows service. I added the "startWinService" operation for 'server' task to start the Windows service for an application server.

Into server configuration on Liberty, the log path can be customize with the LOG_DIR environment variable (see https://www.ibm.com/support/knowledgecenter/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_logging.html). If this action is done, the "start" operation for 'server' task can not be check the message.log file. I added the "serverLogDir" attribut to specify a custom log path 