### PR TITLE
Compatibility with WL 18.0.0.2

### DIFF
--- a/docs/install-liberty.md
+++ b/docs/install-liberty.md
@@ -11,7 +11,7 @@ In certain cases, the Liberty license code may need to be provided in order to i
 | --------- | ------------ | ----------|
 | licenseCode | Liberty profile license code. See [above](#install-liberty-task). | Yes, if `type` is `webProfile6` or `runtimeUrl` specifies a `.jar` file. |
 | version | Exact or wildcard version of the Liberty profile server to install. Available versions are listed in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. Only used if `runtimeUrl` is not set. By default, the latest stable release is used. | No |
-| type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile6`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. Defaults to `webProfile6` if `licenseCode` is set and `webProfile7` otherwise. | No |
+| type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. Defaults to `webProfile7`. | No |
 | runtimeUrl | URL to the Liberty profile's `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
 | baseDir | The base installation directory. The actual installation directory of Liberty profile will be `${baseDir}/wlp`. The default value is `.` (current working directory). | No | 
 | cacheDir | The directory used for caching downloaded files such as the license or `.jar` files. The default value is `${java.io.tmpdir}/wlp-cache`. | No | 

--- a/src/it/tests/install-server-it/build.xml
+++ b/src/it/tests/install-server-it/build.xml
@@ -15,7 +15,7 @@
     <property name="servername" value="wlp.ant.test" />
 
     <target name="installServer">
-        <wlp:install-liberty licenseCode="${wlpLicense}" version="${wlpVersion}" basedir="${target.dir}" />
+        <wlp:install-liberty licenseCode="${wlpLicense}" version="${wlpVersion}" basedir="${target.dir}" type="kernel" />
 
         <delete dir="${wlp.usr.dir}" />
         <delete dir="${wlp.output.dir}" />

--- a/src/main/java/net/wasdev/wlp/ant/install/WasDevInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/WasDevInstaller.java
@@ -136,10 +136,9 @@ public class WasDevInstaller implements Installer {
     }
 
     private String getRuntimeURI(LibertyInfo selected) {
-        String propertyName = ("webProfile6".equalsIgnoreCase(type)) ? "uri" : type;
-        String value = selected.getProperty(propertyName);
+        String value = selected.getProperty(type);
         if (value == null) {
-            throw new BuildException("Archive type " + propertyName + " is not available for Liberty version " + selected.getVersion());
+            throw new BuildException("Archive type " + type + " is not available for Liberty version " + selected.getVersion());
         }
         return value;
     }

--- a/src/main/java/net/wasdev/wlp/ant/install/WasDevInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/WasDevInstaller.java
@@ -69,7 +69,7 @@ public class WasDevInstaller implements Installer {
         }
 
         if (type == null) {
-            type = (licenseCode == null) ? "webProfile7" : "webProfile6";
+            type = "webProfile7";
         }
 
         File cacheDir = new File(task.getCacheDir());


### PR DESCRIPTION
Set default runtime to `webProfile7` and use `wlp-kernel` in tests instead of `wlp-runtime`.