### PR TITLE
Adding useWlpCache property to InstallLibertyTask

### DIFF
--- a/docs/install-liberty.md
+++ b/docs/install-liberty.md
@@ -28,6 +28,7 @@ The following additional parameters are available when downloading a runtime via
 | licenseCode | Liberty profile license code. See [above](#install-liberty-task). | No |
 | username | Username needed for basic authentication. | No | 
 | password | Password needed for basic authentication. | No | 
+| useWlpCache | Enables caching of a Liberty `zip`. Defaults to `true`. Only disable caching if the runtimeUrl points to a local Liberty `zip`. | No |
 
 #### Parameters when installing from Wasdev repository (WebSphere Liberty runtimes)
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>json</artifactId>
             <version>20180813</version>
         </dependency>
+        <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
             <artifactId>json</artifactId>
             <version>20180813</version>
         </dependency>
-        <dependency>
-            <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>1.3.2</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
@@ -64,15 +64,15 @@ public class ArchiveInstaller implements Installer {
         InstallUtils.createDirectory(cacheDir);
 
         // download & install runtime file
-        install(task, cacheDir, runtimeUrl);
+        install(task, cacheDir, runtimeUrl, task.useCacheDir());
 
         // download & install extended file
         if (extendedUrl != null) {
-            install(task, cacheDir, extendedUrl);
+            install(task, cacheDir, extendedUrl, task.useCacheDir());
         }
     }
 
-    private void install(InstallLibertyTask task, File cacheDir, String url) throws Exception {
+    private void install(InstallLibertyTask task, File cacheDir, String url, boolean useWlpCache) throws Exception {
         // download file
         URL downloadURL = new URL(url);
         File cachedFile = new File(cacheDir, InstallUtils.getFile(downloadURL));
@@ -90,11 +90,17 @@ public class ArchiveInstaller implements Installer {
             // install Liberty jar
             task.installLiberty(cachedFile);
         } else {
-            // download zip file
-            task.downloadFile(downloadURL, cachedFile);
+            if (useWlpCache) {
+                // download zip file
+                task.downloadFile(downloadURL, cachedFile);
 
-            // unzip
-            task.unzipLiberty(cachedFile);
+                // unzip
+                task.unzipLiberty(cachedFile);
+            } else {
+                // unzipping straight from runtimeUrl
+                // must have file on file system to skip caching
+                task.unzipLiberty(new File(task.getRuntimeUrl()));
+            }
         }
     }
 

--- a/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
@@ -91,27 +91,21 @@ public class ArchiveInstaller implements Installer {
             // install Liberty jar
             task.installLiberty(cachedFile);
         } else {
-            if (task.getUseWlpChache()) {
-                // download zip file
+            // download zip file
+            if (!cachedFile.exists()) {
                 task.downloadFile(downloadURL, cachedFile);
-
-                // unzip
-                task.unzipLiberty(cachedFile);
-            } else {
-                // unzipping straight from runtimeUrl
-                // must have file on file system to skip caching
-                File runtimeFile = new File(new URI(task.getRuntimeUrl()));
-
-                if (runtimeFile.exists()) {
-
-                    long startTime = System.currentTimeMillis();
-                    task.unzipLiberty(runtimeFile);
-                    long totalTime = System.currentTimeMillis() - startTime;
-                    System.out.println("Unzip took " + totalTime + " milliseconds." );
-                } else {
-                    throw new BuildException("Liberty runtime zip not found at: " + task.getRuntimeUrl());
-                }
             }
+            long startTime = System.currentTimeMillis();
+
+            File unzippedCachedFile = new File (cacheDir, cachedFile.getName().substring(0, cachedFile.getName().length() - 4));
+            //Unzip file in cacheDir
+            if (!unzippedCachedFile.exists()) {
+                Unzip.unzipToDirectory(cachedFile, unzippedCachedFile);
+            }
+            
+            task.copyLiberty(unzippedCachedFile);
+            long totalTime = System.currentTimeMillis() - startTime;
+            System.out.println("Unzip and copy took " + totalTime + " milliseconds." );
         }
     }
 

--- a/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
@@ -103,7 +103,11 @@ public class ArchiveInstaller implements Installer {
                 File runtimeFile = new File(new URI(task.getRuntimeUrl()));
 
                 if (runtimeFile.exists()) {
+
+                    long startTime = System.currentTimeMillis();
                     task.unzipLiberty(runtimeFile);
+                    long totalTime = System.currentTimeMillis() - startTime;
+                    System.out.println("Unzip took " + totalTime + " milliseconds." );
                 } else {
                     throw new BuildException("Liberty runtime zip not found at: " + task.getRuntimeUrl());
                 }

--- a/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
@@ -99,7 +99,13 @@ public class ArchiveInstaller implements Installer {
             } else {
                 // unzipping straight from runtimeUrl
                 // must have file on file system to skip caching
-                task.unzipLiberty(new File(task.getRuntimeUrl()));
+                File runtimeFile = new File(task.getRuntimeUrl());
+
+                if (runtimeFile.exists()) {
+                    task.unzipLiberty(runtimeFile);
+                } else {
+                    throw new BuildException("Liberty runtime zip not found at: " + task.getRuntimeUrl());
+                }
             }
         }
     }

--- a/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/ArchiveInstaller.java
@@ -17,6 +17,7 @@ package net.wasdev.wlp.ant.install;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
@@ -64,15 +65,15 @@ public class ArchiveInstaller implements Installer {
         InstallUtils.createDirectory(cacheDir);
 
         // download & install runtime file
-        install(task, cacheDir, runtimeUrl, task.useCacheDir());
+        install(task, cacheDir, runtimeUrl);
 
         // download & install extended file
         if (extendedUrl != null) {
-            install(task, cacheDir, extendedUrl, task.useCacheDir());
+            install(task, cacheDir, extendedUrl);
         }
     }
 
-    private void install(InstallLibertyTask task, File cacheDir, String url, boolean useWlpCache) throws Exception {
+    private void install(InstallLibertyTask task, File cacheDir, String url) throws Exception {
         // download file
         URL downloadURL = new URL(url);
         File cachedFile = new File(cacheDir, InstallUtils.getFile(downloadURL));
@@ -90,7 +91,7 @@ public class ArchiveInstaller implements Installer {
             // install Liberty jar
             task.installLiberty(cachedFile);
         } else {
-            if (useWlpCache) {
+            if (task.getUseWlpChache()) {
                 // download zip file
                 task.downloadFile(downloadURL, cachedFile);
 
@@ -99,7 +100,7 @@ public class ArchiveInstaller implements Installer {
             } else {
                 // unzipping straight from runtimeUrl
                 // must have file on file system to skip caching
-                File runtimeFile = new File(task.getRuntimeUrl());
+                File runtimeFile = new File(new URI(task.getRuntimeUrl()));
 
                 if (runtimeFile.exists()) {
                     task.unzipLiberty(runtimeFile);

--- a/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
@@ -27,6 +27,9 @@ import org.apache.tools.ant.taskdefs.Get;
 import org.apache.tools.ant.taskdefs.Get.DownloadProgress;
 import org.apache.tools.ant.taskdefs.Java;
 
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.core.ZipFile;
+
 /*
  * Install Liberty profile server task.
  */
@@ -137,7 +140,7 @@ public class InstallLibertyTask extends AbstractTask {
     }
 
     protected void unzipLiberty(File zipFile) throws Exception {
-        Unzip.unzipToDirectory(zipFile, new File(baseDir));
+        new ZipFile(zipFile).extractAll(baseDir);
     }
 
     protected void checkLicense(String actualLicenseCode) {

--- a/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
@@ -21,14 +21,12 @@ import java.net.URL;
 
 import net.wasdev.wlp.ant.AbstractTask;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Get;
 import org.apache.tools.ant.taskdefs.Get.DownloadProgress;
 import org.apache.tools.ant.taskdefs.Java;
-
-import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.core.ZipFile;
 
 /*
  * Install Liberty profile server task.
@@ -140,7 +138,11 @@ public class InstallLibertyTask extends AbstractTask {
     }
 
     protected void unzipLiberty(File zipFile) throws Exception {
-        new ZipFile(zipFile).extractAll(baseDir);
+        Unzip.unzipToDirectory(zipFile, new File(baseDir));
+    }
+
+    protected void copyLiberty(File libertyFolder) throws Exception {
+        FileUtils.copyDirectory(libertyFolder, new File(baseDir));
     }
 
     protected void checkLicense(String actualLicenseCode) {
@@ -167,11 +169,7 @@ public class InstallLibertyTask extends AbstractTask {
     }
 
     public String getCacheDir() {
-        if (getUseWlpChache()) {
-            return cacheDir;
-        } else {
-            return baseDir;
-        }
+        return cacheDir;
     }
 
     public void setCacheDir(String cacheDir) {

--- a/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
@@ -164,7 +164,7 @@ public class InstallLibertyTask extends AbstractTask {
     }
 
     public String getCacheDir() {
-        if (useWlpCache) {
+        if (getUseWlpChache()) {
             return cacheDir;
         } else {
             return baseDir;
@@ -175,8 +175,12 @@ public class InstallLibertyTask extends AbstractTask {
         this.cacheDir = cacheDir;
     }
 
-    public boolean useCacheDir() {
+    public boolean getUseWlpChache() {
         return useWlpCache;
+    }
+
+    public void setUseWlpCache(boolean useWlpCache) {
+        this.useWlpCache = useWlpCache;
     }
 
     public String getLicenseCode() {

--- a/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/install/InstallLibertyTask.java
@@ -44,6 +44,7 @@ public class InstallLibertyTask extends AbstractTask {
     private long maxDownloadTime;
     private boolean offline;
     private boolean useOpenLiberty;
+    private boolean useWlpCache = true;
     
 
     @Override
@@ -163,11 +164,19 @@ public class InstallLibertyTask extends AbstractTask {
     }
 
     public String getCacheDir() {
-        return cacheDir;
+        if (useWlpCache) {
+            return cacheDir;
+        } else {
+            return baseDir;
+        }
     }
 
     public void setCacheDir(String cacheDir) {
         this.cacheDir = cacheDir;
+    }
+
+    public boolean useCacheDir() {
+        return useWlpCache;
     }
 
     public String getLicenseCode() {


### PR DESCRIPTION
Can be used to skip caching. Only use if there is a copy of the file on the file system, i.e. a copy in `.m2` or `.gradle`.