### PR TITLE
Adding fix for bad archive path with spaces during package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
     - oraclejdk11
 env:
     - WLP_VERSION=18.0.0_04 WLP_LICENSE=L-CTUR-B4WNHE
-    - WLP_VERSION=19.0.0_02 WLP_LICENSE=L-CTUR-B8GJRP
+    - WLP_VERSION=19.0.0_03 WLP_LICENSE=L-CTUR-B9JQES
 matrix:
     exclude:
     - jdk: oraclejdk11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
           WLP_VERSION: 18.0.0_04
           WLP_LICENSE: L-CTUR-B4WNHE
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          WLP_VERSION: 19.0.0_02
-          WLP_LICENSE: L-CTUR-B8GJRP
+          WLP_VERSION: 19.0.0_03
+          WLP_LICENSE: L-CTUR-B9JQES
 
 install:
     - cmd: |

--- a/src/main/java/net/wasdev/wlp/ant/AbstractTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/AbstractTask.java
@@ -34,8 +34,6 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 
-import net.wasdev.wlp.common.plugins.util.OSUtil;
-
 public abstract class AbstractTask extends Task {
 
     protected File installDir;
@@ -47,6 +45,7 @@ public abstract class AbstractTask extends Task {
 
     protected String ref;
 
+    protected static String osName;
     protected static boolean isWindows;
 
     protected ProcessBuilder processBuilder;
@@ -128,7 +127,8 @@ public abstract class AbstractTask extends Task {
         }
 
         // Check for windows..
-        isWindows = OSUtil.isWindows();
+        osName = System.getProperty("os.name", "unknown").toLowerCase();
+        isWindows = osName.indexOf("windows") >= 0;
 
     }
 

--- a/src/main/java/net/wasdev/wlp/ant/AbstractTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/AbstractTask.java
@@ -34,6 +34,8 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 
+import net.wasdev.wlp.common.plugins.util.OSUtil;
+
 public abstract class AbstractTask extends Task {
 
     protected File installDir;
@@ -45,7 +47,6 @@ public abstract class AbstractTask extends Task {
 
     protected String ref;
 
-    protected static String osName;
     protected static boolean isWindows;
 
     protected ProcessBuilder processBuilder;
@@ -127,8 +128,7 @@ public abstract class AbstractTask extends Task {
         }
 
         // Check for windows..
-        osName = System.getProperty("os.name", "unknown").toLowerCase();
-        isWindows = osName.indexOf("windows") >= 0;
+        isWindows = OSUtil.isWindows();
 
     }
 

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -444,7 +444,7 @@ public class ServerTask extends AbstractTask {
             if (archive.isDirectory()) {
                 throw new BuildException("The archive attribute must specify a file");
             }
-            command.add("--archive=" + archive);
+            command.add("--archive=" + archive.toString().replaceAll(" ", "\\\\ "));
         }
     }
     

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -444,7 +444,11 @@ public class ServerTask extends AbstractTask {
             if (archive.isDirectory()) {
                 throw new BuildException("The archive attribute must specify a file");
             }
-            command.add("--archive=" + archive.toString().replaceAll(" ", "\\\\ "));
+            if (isWindows) {
+                command.add("--archive=" + "\"" + archive.toString() + "\"");
+            } else {
+                command.add("--archive=" + archive.toString().replaceAll(" ", "\\\\ "));
+            }
         }
     }
     


### PR DESCRIPTION
Packaging on 19.0.0.2 and 19.0.0.3 failed when spaces were included in an archive name.

e.g. `.../path with spaces/...`

Escaped the spaces before we returned the archive parameter to the command that was using it.