### PR TITLE
Support no-password option on server create

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -26,7 +26,7 @@ Parameters supported by this task in addition to the [common parameters](common-
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
-| noPassword | Disable generation of keystore password. The default value is `false`. Only used with the `create` operation. | No | 
+| noPassword | Disable generation of default keystore password. The default value is `false`. Only used with the `create` operation. | No | 
 
 
 #### Examples

--- a/docs/server.md
+++ b/docs/server.md
@@ -26,6 +26,8 @@ Parameters supported by this task in addition to the [common parameters](common-
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
+| noPassword | Disable generation of keystore password. The default value is `false`. Only used with the `create` operation. | No | 
+
 
 #### Examples
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -26,7 +26,7 @@ Parameters supported by this task in addition to the [common parameters](common-
 | archive | Location of the target archive file. Only used with the `package` or `dump` operations. | No |
 | template | Name of the template to use when creating a new server. Only used with the `create` operation. | No |
 | resultProperty | Name of a property in which the server status will be stored. By default the server status will be stored under `wlp.<serverName>.status` property. Only used with the `status` operation. | No |
-| noPassword | Disable generation of default keystore password. The default value is `false`. Only used with the `create` operation. | No | 
+| noPassword | If true, disable generation of the default keystore password by specifying the --no-password option when creating a new server. This option was added in 18.0.0.3. The default value is false. Only used with the `create` operation. | No | 
 
 
 #### Examples

--- a/src/main/java/net/wasdev/wlp/ant/ServerTask.java
+++ b/src/main/java/net/wasdev/wlp/ant/ServerTask.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2015.
+ * (C) Copyright IBM Corporation 2014, 2019.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,8 @@ public class ServerTask extends AbstractTask {
     
     // used with 'create' operation
     private String template;
-    
+    private boolean noPassword = false;
+   
     // used with 'package' operation
     private String os;
     
@@ -416,6 +417,7 @@ public class ServerTask extends AbstractTask {
         if (template != null) {
             command.add("--template=" + template);
         }
+        addNoPasswordOption(command);
         processBuilder.command(command);
         Process p = processBuilder.start();
         checkReturnCode(p, processBuilder.command().toString(), ReturnCode.OK.getValue());
@@ -467,6 +469,12 @@ public class ServerTask extends AbstractTask {
     private void addCleanOption(List<String> command) {
         if (clean) {
             command.add("--clean");
+        }
+    }
+
+    private void addNoPasswordOption(List<String> command) {
+        if (noPassword) {
+            command.add("--no-password");
         }
     }
 
@@ -567,6 +575,21 @@ public class ServerTask extends AbstractTask {
         this.template = template;
     }
     
+    /**
+     * @return the noPassword setting
+     */
+    public boolean isNoPassword() {
+        return noPassword;
+    }
+
+    /**
+     * @param noPassword
+     *            the noPassword option value to set
+     */
+    public void setNoPassword(boolean noPassword) {
+        this.noPassword = noPassword;
+    }
+
     public void setUseEmbeddedServer(boolean useEmbeddedServer) {
         this.useEmbeddedServer = useEmbeddedServer;
     }


### PR DESCRIPTION
This adds the ant functionality needed by maven/gradle requested in https://github.com/WASdev/ci.maven/issues/434. One question I have is do we need to guard against this option being used on an earlier version of the Liberty server that does not support it?